### PR TITLE
Extend serialization of EntityDescriptor and Assertion for use with IdPs

### DIFF
--- a/src/idp/verified_request.rs
+++ b/src/idp/verified_request.rs
@@ -57,3 +57,23 @@ impl std::ops::Deref for VerifiedAuthnRequest {
         &self.0
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::UnverifiedAuthnRequest;
+    #[test]
+    fn test_request_deserialize_and_serialize() {
+        let authn_request_xml = include_str!("../../test_vectors/authn_request.xml");
+        let unverified =
+            UnverifiedAuthnRequest::from_xml(authn_request_xml).expect("failed to parse");
+        let expected_verified = unverified
+            .try_verify_self_signed()
+            .expect("failed to verify self signed signature");
+        let verified_request_xml = expected_verified
+            .to_xml()
+            .expect("Failed to serialize verified authn request");
+        let reparsed_unverified =
+            UnverifiedAuthnRequest::from_xml(&verified_request_xml).expect("failed to parse");
+        assert_eq!(reparsed_unverified.request, expected_verified.0);
+    }
+}

--- a/src/metadata/entity_descriptor.rs
+++ b/src/metadata/entity_descriptor.rs
@@ -39,7 +39,7 @@ pub struct EntityDescriptor {
     #[serde(rename = "AffiliationDescriptor")]
     pub affiliation_descriptors: Option<AffiliationDescriptor>,
     #[serde(rename = "ContactPerson")]
-    pub contact_person: Option<ContactPerson>,
+    pub contact_person: Option<Vec<ContactPerson>>,
     #[serde(rename = "Organization")]
     pub organization: Option<Organization>,
 }
@@ -94,8 +94,10 @@ impl EntityDescriptor {
         if let Some(organization) = &self.organization {
             writer.write(organization.to_xml()?.as_bytes())?;
         }
-        if let Some(contact_person) = &self.contact_person {
-            writer.write(contact_person.to_xml()?.as_bytes())?;
+        if let Some(contact_persons) = &self.contact_person {
+            for contact_person in contact_persons {
+                writer.write(contact_person.to_xml()?.as_bytes())?;
+            }
         }
         writer.write_event(Event::End(BytesEnd::borrowed(root_name.as_bytes())))?;
 

--- a/src/metadata/entity_descriptor.rs
+++ b/src/metadata/entity_descriptor.rs
@@ -91,6 +91,10 @@ impl EntityDescriptor {
             writer.write(descriptor.to_xml()?.as_bytes())?;
         }
 
+        for descriptor in self.idp_sso_descriptors.as_ref().unwrap_or(&vec![]) {
+            writer.write(descriptor.to_xml()?.as_bytes())?;
+        }
+
         if let Some(organization) = &self.organization {
             writer.write(organization.to_xml()?.as_bytes())?;
         }

--- a/src/metadata/entity_descriptor.rs
+++ b/src/metadata/entity_descriptor.rs
@@ -108,3 +108,42 @@ impl EntityDescriptor {
         Ok(String::from_utf8(write_buf)?)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::EntityDescriptor;
+
+    #[test]
+    fn test_sp_entity_descriptor() {
+        let input_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/sp_metadata.xml"
+        ));
+        let entity_descriptor: EntityDescriptor = input_xml
+            .parse()
+            .expect("Failed to parse sp_metadata.xml into an EntityDescriptor");
+        let output_xml = entity_descriptor
+            .to_xml()
+            .expect("Failed to convert EntityDescriptor to xml");
+        let reparsed_entity_descriptor: EntityDescriptor =output_xml.parse().expect("Failed to parse EntityDescriptor");
+
+        assert_eq!(reparsed_entity_descriptor, entity_descriptor);
+    }
+
+    #[test]
+    fn test_idp_entity_descriptor() {
+        let input_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/idp_metadata.xml"
+        ));
+        let entity_descriptor: EntityDescriptor = input_xml
+            .parse()
+            .expect("Failed to parse sp_metadata.xml into an EntityDescriptor");
+        let output_xml = entity_descriptor
+            .to_xml()
+            .expect("Failed to convert EntityDescriptor to xml");
+        let reparsed_entity_descriptor: EntityDescriptor =output_xml.parse().expect("Failed to parse EntityDescriptor");
+
+        assert_eq!(reparsed_entity_descriptor, entity_descriptor);
+    }
+}

--- a/src/metadata/entity_descriptor.rs
+++ b/src/metadata/entity_descriptor.rs
@@ -76,6 +76,10 @@ impl EntityDescriptor {
                     .as_ref(),
             ))
         }
+        if let Some(cache_duration) = &self.cache_duration {
+            root.push_attribute(("cacheDuration", cache_duration.as_ref()));
+        }
+
         root.push_attribute(("xmlns:md", "urn:oasis:names:tc:SAML:2.0:metadata"));
         root.push_attribute(("xmlns:saml", "urn:oasis:names:tc:SAML:2.0:assertion"));
         root.push_attribute(("xmlns:mdrpi", "urn:oasis:names:tc:SAML:metadata:rpi"));
@@ -98,6 +102,7 @@ impl EntityDescriptor {
         if let Some(organization) = &self.organization {
             writer.write(organization.to_xml()?.as_bytes())?;
         }
+
         if let Some(contact_persons) = &self.contact_person {
             for contact_person in contact_persons {
                 writer.write(contact_person.to_xml()?.as_bytes())?;

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -220,6 +220,10 @@ impl IdpSsoDescriptor {
             writer.write(service.to_xml("md:SingleLogoutService")?.as_bytes())?;
         }
 
+        for service in &self.single_sign_on_services {
+            writer.write(service.to_xml("md:SingleSignOnService")?.as_bytes())?;
+        }
+
         for service in &self.manage_name_id_services {
             writer.write(service.to_xml("md:ManageNameIDService")?.as_bytes())?;
         }

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -162,7 +162,7 @@ pub struct IdpSsoDescriptor {
     pub attributes: Vec<Attribute>,
 }
 
-const NAME: &str = "md:IdPSSODescriptor";
+const NAME: &str = "md:IDPSSODescriptor";
 
 impl IdpSsoDescriptor {
     fn to_xml(&self) -> Result<String, Box<dyn std::error::Error>> {

--- a/src/metadata/sp_sso_descriptor.rs
+++ b/src/metadata/sp_sso_descriptor.rs
@@ -89,6 +89,13 @@ impl SpSsoDescriptor {
             ));
         }
 
+        if let Some(authn_requests_signed) = &self.authn_requests_signed {
+            root.push_attribute((
+                "AuthnRequestsSigned",
+                authn_requests_signed.to_string().as_ref(),
+            ));
+        }
+
         writer.write_event(Event::Start(root))?;
 
         if let Some(key_descriptors) = &self.key_descriptors {

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -94,16 +94,16 @@ impl Assertion {
         writer.write_event(Event::Start(root))?;
         writer.write(self.issuer.to_xml()?.as_bytes())?;
 
+        if let Some(signature) = &self.signature {
+            writer.write(signature.to_xml()?.as_bytes())?;
+        }
+
         if let Some(subject) = &self.subject {
             writer.write(subject.to_xml()?.as_bytes())?;
         }
 
         if let Some(conditions) = &self.conditions {
             writer.write(conditions.to_xml()?.as_bytes())?;
-        }
-
-        if let Some(signature) = &self.signature {
-            writer.write(signature.to_xml()?.as_bytes())?;
         }
 
         if let Some(statements) = &self.authn_statements {

--- a/src/schema/response.rs
+++ b/src/schema/response.rs
@@ -106,3 +106,47 @@ impl Response {
         Ok(String::from_utf8(write_buf)?)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::Response;
+
+    #[test]
+    fn test_deserialize_serialize_response() {
+        let response_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/response.xml",
+        ));
+        let expected_response: Response = response_xml.parse().expect("failed to parse response.xml");
+        let serialized_response = expected_response.to_xml().expect("failed to convert response to xml");
+        let actual_response: Response = serialized_response.parse().expect("failed to re-parse response");
+
+        assert_eq!(expected_response, actual_response);
+    }
+
+    #[test]
+    fn test_deserialize_serialize_response_with_signed_assertion() {
+                let response_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/response_signed_assertion.xml",
+        ));
+        let expected_response: Response = response_xml.parse().expect("failed to parse response_signed_assertion.xml");
+        let serialized_response = expected_response.to_xml().expect("failed to convert response to xml");
+        let actual_response: Response = serialized_response.parse().expect("failed to re-parse response");
+
+        assert_eq!(expected_response, actual_response);
+    }
+
+    #[test]
+    fn test_deserialize_serialize_signed_response() {
+                let response_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/response_signed.xml",
+        ));
+        let expected_response: Response = response_xml.parse().expect("failed to parse response_signed.xml");
+        let serialized_response = expected_response.to_xml().expect("failed to convert response to xml");
+        let actual_response: Response = serialized_response.parse().expect("failed to re-parse response");
+
+        assert_eq!(expected_response, actual_response);
+    }
+}

--- a/src/service_provider.rs
+++ b/src/service_provider.rs
@@ -226,7 +226,11 @@ impl ServiceProvider {
             entity_id,
             valid_until,
             sp_sso_descriptors: Some(vec![sso_sp_descriptor]),
-            contact_person: self.contact_person.clone(),
+            contact_person: if let Some(contact_person) = &self.contact_person {
+                Some(vec![contact_person.clone()])
+            } else {
+                None
+            },
             ..EntityDescriptor::default()
         })
     }

--- a/test_vectors/idp_metadata.xml
+++ b/test_vectors/idp_metadata.xml
@@ -1,0 +1,34 @@
+
+<md:EntityDescriptor entityID="https://sso.example.org/idp" validUntil="2017-08-30T19:10:29Z"
+    xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
+    xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
+    xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+
+    <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <md:KeyDescriptor use="signing">
+            <ds:KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>MIICZDCCAg6gAwIBAgICBr8wDQYJKoZIhvcNAQEEBQAwgZIxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRQwEgYDVQQHEwtTYW50YSBDbGFyYTEeMBwGA1UEChMVU3VuIE1pY3Jvc3lzdGVtcyBJbmMuMRowGAYDVQQLExFJZGVudGl0eSBTZXJ2aWNlczEcMBoGA1UEAxMTQ2VydGlmaWNhdGUgTWFuYWdlcjAeFw0wNzAzMDcyMTUwMDVaFw0xMDEyMDEyMTUwMDVaMDsxFDASBgNVBAoTC2V4YW1wbGUuY29tMSMwIQYDVQQDExpMb2FkQmFsYW5jZXItMy5leGFtcGxlLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAlOhN9HddLMpE3kCjkPSOFpCkDxTNuhMhcgBkYmSEF/iJcQsLX/gapO+W1SIpwqfsjzR5ZvEdtc/8hGumRHqcX3r6XrU0dESM6MW5AbNNJsBnwIV6xZ5QozB4wL4zREhwzwwYejDVQ/x+8NRESI3ym17tDLEuAKyQBueubgjfic0CAwEAAaNgMF4wEQYJYIZIAYb4QgEBBAQDAgZAMA4GA1UdDwEB/wQEAwIE8DAfBgNVHSMEGDAWgBQ7oCE35Uwn7FsjS01w5e3DA1CrrjAYBgNVHREEETAPgQ1tYWxsYUBzdW4uY29tMA0GCSqGSIb3DQEBBAUAA0EAGhJhep7X2hqWJWQoXFcdU7eQ</ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </md:KeyDescriptor>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.org/SAML2/SSO/Redirect"/>
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.org/SAML2/SSO/POST"/>
+    </md:IDPSSODescriptor>
+    <md:Organization>
+        <md:OrganizationName xml:lang="en">Example.org Non-Profit Org</md:OrganizationName>
+        <md:OrganizationDisplayName xml:lang="en">Example.org</md:OrganizationDisplayName>
+        <md:OrganizationURL xml:lang="en">https://www.example.org/</md:OrganizationURL>
+    </md:Organization>
+    <md:ContactPerson contactType="technical">
+        <md:SurName>SAML Technical Support</md:SurName>
+        <md:EmailAddress>mailto:technical-support@example.org</md:EmailAddress>
+    </md:ContactPerson>
+    <md:ContactPerson contactType="support">
+        <md:GivenName>SAML Support</md:GivenName>
+        <md:EmailAddress>mailto:support@example.org</md:EmailAddress>
+    </md:ContactPerson> 
+</md:EntityDescriptor>

--- a/test_vectors/response.xml
+++ b/test_vectors/response.xml
@@ -1,0 +1,37 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6" Version="2.0" IssueInstant="2014-07-17T01:01:48Z" Destination="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685">
+  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="_d71a3a8e9fcc45c9e9d248ef7049393fc8f04e5f75" Version="2.0" IssueInstant="2014-07-17T01:01:48Z">
+    <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
+    <saml:Subject>
+      <saml:NameID SPNameQualifier="http://sp.example.com/demo1/metadata.php" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">_ce3d2948b4cf20146dee0a0b3dd6f69b6cf86f62d7</saml:NameID>
+      <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml:SubjectConfirmationData NotOnOrAfter="2024-01-18T06:21:48Z" Recipient="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"/>
+      </saml:SubjectConfirmation>
+    </saml:Subject>
+    <saml:Conditions NotBefore="2014-07-17T01:01:18Z" NotOnOrAfter="2024-01-18T06:21:48Z">
+      <saml:AudienceRestriction>
+        <saml:Audience>http://sp.example.com/demo1/metadata.php</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AuthnStatement AuthnInstant="2014-07-17T01:01:48Z" SessionNotOnOrAfter="2024-07-17T09:01:48Z" SessionIndex="_be9967abd904ddcae3c0eb4189adbe3f71e327cf93">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="uid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">test</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="mail" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">test@example.com</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="eduPersonAffiliation" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">users</saml:AttributeValue>
+        <saml:AttributeValue xsi:type="xs:string">examplerole1</saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>

--- a/test_vectors/response_signed.xml
+++ b/test_vectors/response_signed.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="pfxf63324d7-7ba2-b371-90d6-171637d97253" Version="2.0" IssueInstant="2014-07-17T01:01:48Z" Destination="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685">
+  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+    <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+  <ds:Reference URI="#pfxf63324d7-7ba2-b371-90d6-171637d97253"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/><ds:DigestValue>gciSu0u9H5QMP776LBbSg8ai9BM=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>d8fP51sHmS+BNEmlXVqkJ2ZMTdBeeYlfUL3IUVXKv4xgsHbmbYPUjXFFwNyUDt5SMK/lo70NVlVyfmLGCHByah1v4en10WPU+WOj6BypxOVi/BRZrY1Dj1CKL9ro1Q2fUFnHu33MikADpwxCbxjpsUxPcDjX8sNrVvswbab6cxc=</ds:SignatureValue>
+<ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIICajCCAdOgAwIBAgIBADANBgkqhkiG9w0BAQ0FADBSMQswCQYDVQQGEwJ1czETMBEGA1UECAwKQ2FsaWZvcm5pYTEVMBMGA1UECgwMT25lbG9naW4gSW5jMRcwFQYDVQQDDA5zcC5leGFtcGxlLmNvbTAeFw0xNDA3MTcxNDEyNTZaFw0xNTA3MTcxNDEyNTZaMFIxCzAJBgNVBAYTAnVzMRMwEQYDVQQIDApDYWxpZm9ybmlhMRUwEwYDVQQKDAxPbmVsb2dpbiBJbmMxFzAVBgNVBAMMDnNwLmV4YW1wbGUuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDZx+ON4IUoIWxgukTb1tOiX3bMYzYQiwWPUNMp+Fq82xoNogso2bykZG0yiJm5o8zv/sd6pGouayMgkx/2FSOdc36T0jGbCHuRSbtia0PEzNIRtmViMrt3AeoWBidRXmZsxCNLwgIV6dn2WpuE5Az0bHgpZnQxTKFek0BMKU/d8wIDAQABo1AwTjAdBgNVHQ4EFgQUGHxYqZYyX7cTxKVODVgZwSTdCnwwHwYDVR0jBBgwFoAUGHxYqZYyX7cTxKVODVgZwSTdCnwwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOBgQByFOl+hMFICbd3DJfnp2Rgd/dqttsZG/tyhILWvErbio/DEe98mXpowhTkC04ENprOyXi7ZbUqiicF89uAGyt1oqgTUCD1VsLahqIcmrzgumNyTwLGWo17WDAa1/usDhetWAMhgzF/Cnf5ek0nK00m0YZGyc4LzgD0CROMASTWNg==</ds:X509Certificate></ds:X509Data></ds:KeyInfo></ds:Signature>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="_d71a3a8e9fcc45c9e9d248ef7049393fc8f04e5f75" Version="2.0" IssueInstant="2014-07-17T01:01:48Z">
+    <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
+    <saml:Subject>
+      <saml:NameID SPNameQualifier="http://sp.example.com/demo1/metadata.php" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">_ce3d2948b4cf20146dee0a0b3dd6f69b6cf86f62d7</saml:NameID>
+      <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml:SubjectConfirmationData NotOnOrAfter="2024-01-18T06:21:48Z" Recipient="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"/>
+      </saml:SubjectConfirmation>
+    </saml:Subject>
+    <saml:Conditions NotBefore="2014-07-17T01:01:18Z" NotOnOrAfter="2024-01-18T06:21:48Z">
+      <saml:AudienceRestriction>
+        <saml:Audience>http://sp.example.com/demo1/metadata.php</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AuthnStatement AuthnInstant="2014-07-17T01:01:48Z" SessionNotOnOrAfter="2024-07-17T09:01:48Z" SessionIndex="_be9967abd904ddcae3c0eb4189adbe3f71e327cf93">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="uid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">test</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="mail" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">test@example.com</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="eduPersonAffiliation" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">users</saml:AttributeValue>
+        <saml:AttributeValue xsi:type="xs:string">examplerole1</saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>

--- a/test_vectors/response_signed_assertion.xml
+++ b/test_vectors/response_signed_assertion.xml
@@ -1,0 +1,41 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6" Version="2.0" IssueInstant="2014-07-17T01:01:48Z" Destination="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685">
+  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="pfx899e3531-c2e6-6af4-5cde-258744a11414" Version="2.0" IssueInstant="2014-07-17T01:01:48Z">
+    <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+    <ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+  <ds:Reference URI="#pfx899e3531-c2e6-6af4-5cde-258744a11414"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/><ds:DigestValue>YmjY1aj24539ZQO/Evpm0IosNGM=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>uUsyh4JxV9ow9h3hxt5FOh0ah0aHOoIZPhelbjLC/zKw58o7tucSg5nf8ZfY48pao1+A6O/X4HTfi/IeYWrTtuxBdTR5Y/Lb8YAQIw8KUV/+8ijFS9E4HtlBjJSi0rmeMgRWBvdb90p+t9TP5PjKfdFI5USY6Bt6FvlrzybgTvk=</ds:SignatureValue>
+<ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIICajCCAdOgAwIBAgIBADANBgkqhkiG9w0BAQ0FADBSMQswCQYDVQQGEwJ1czETMBEGA1UECAwKQ2FsaWZvcm5pYTEVMBMGA1UECgwMT25lbG9naW4gSW5jMRcwFQYDVQQDDA5zcC5leGFtcGxlLmNvbTAeFw0xNDA3MTcxNDEyNTZaFw0xNTA3MTcxNDEyNTZaMFIxCzAJBgNVBAYTAnVzMRMwEQYDVQQIDApDYWxpZm9ybmlhMRUwEwYDVQQKDAxPbmVsb2dpbiBJbmMxFzAVBgNVBAMMDnNwLmV4YW1wbGUuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDZx+ON4IUoIWxgukTb1tOiX3bMYzYQiwWPUNMp+Fq82xoNogso2bykZG0yiJm5o8zv/sd6pGouayMgkx/2FSOdc36T0jGbCHuRSbtia0PEzNIRtmViMrt3AeoWBidRXmZsxCNLwgIV6dn2WpuE5Az0bHgpZnQxTKFek0BMKU/d8wIDAQABo1AwTjAdBgNVHQ4EFgQUGHxYqZYyX7cTxKVODVgZwSTdCnwwHwYDVR0jBBgwFoAUGHxYqZYyX7cTxKVODVgZwSTdCnwwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOBgQByFOl+hMFICbd3DJfnp2Rgd/dqttsZG/tyhILWvErbio/DEe98mXpowhTkC04ENprOyXi7ZbUqiicF89uAGyt1oqgTUCD1VsLahqIcmrzgumNyTwLGWo17WDAa1/usDhetWAMhgzF/Cnf5ek0nK00m0YZGyc4LzgD0CROMASTWNg==</ds:X509Certificate></ds:X509Data></ds:KeyInfo></ds:Signature>
+    <saml:Subject>
+      <saml:NameID SPNameQualifier="http://sp.example.com/demo1/metadata.php" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">_ce3d2948b4cf20146dee0a0b3dd6f69b6cf86f62d7</saml:NameID>
+      <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml:SubjectConfirmationData NotOnOrAfter="2024-01-18T06:21:48Z" Recipient="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"/>
+      </saml:SubjectConfirmation>
+    </saml:Subject>
+    <saml:Conditions NotBefore="2014-07-17T01:01:18Z" NotOnOrAfter="2024-01-18T06:21:48Z">
+      <saml:AudienceRestriction>
+        <saml:Audience>http://sp.example.com/demo1/metadata.php</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AuthnStatement AuthnInstant="2014-07-17T01:01:48Z" SessionNotOnOrAfter="2024-07-17T09:01:48Z" SessionIndex="_be9967abd904ddcae3c0eb4189adbe3f71e327cf93">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="uid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">test</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="mail" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">test@example.com</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="eduPersonAffiliation" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">users</saml:AttributeValue>
+        <saml:AttributeValue xsi:type="xs:string">examplerole1</saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>


### PR DESCRIPTION
Adds:

- Serialization of IdP SSO descriptors in the metadata
- Add assertion signature just after the `Issuer` element
- Allow multiple contact people in metadata
- Include cache duration in metadata
- Some tests to make sure all the serialized fields are also deserialized

As mentioned in my email, I've been using samael to a tools for mocking IdPs and I've tried to fix a few of the issues I ran into. The only other outstanding issue I've had was allowing signing the response assertion, rather than the whole assertion. I've got it working on a different branch but the interface isn't great. I'm thinking of using the builder pattern for signing responses, though that's something for a different issue/PR!