### PR TITLE
Accept multiple X509 certificates and parse them correctly

### DIFF
--- a/src/idp/sp_extractor.rs
+++ b/src/idp/sp_extractor.rs
@@ -81,15 +81,13 @@ impl SPMetadataExtractor {
                     let data = kd
                         .iter()
                         .filter(|d| d.is_signing())
-                        .map(|d| {
+                        .flat_map(|d| {
                             d.key_info
                                 .x509_data
-                                .as_ref()
-                                .map(|d| d.certificate.as_ref())
-                                .unwrap_or(None)
+                                .iter()
+                                .flat_map(|d| d.certificates.iter())
                         })
                         .next()
-                        .unwrap_or(None)
                         .ok_or(Error::NoCertificate)?;
 
                     return Ok(crypto::decode_x509_cert(data.as_str())?);

--- a/src/idp/tests.rs
+++ b/src/idp/tests.rs
@@ -169,7 +169,9 @@ fn test_signed_response_fingerprint() {
         .x509_data
         .clone()
         .unwrap()
-        .certificate
+        .certificates
+        .first()
+        .cloned()
         .unwrap();
     let der_cert =
         crate::crypto::decode_x509_cert(&base64_cert).expect("failed to decode cert ");
@@ -200,7 +202,7 @@ fn test_do_not_accept_unsigned_response() {
         .key_descriptors[0]
         .key_info
         .x509_data.as_ref().unwrap()
-        .certificate.as_ref().unwrap().len() > 0);
+        .certificates.first().unwrap().len() > 0);
 
     let unsigned_response_xml = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),

--- a/src/idp/verified_request.rs
+++ b/src/idp/verified_request.rs
@@ -16,31 +16,39 @@ impl<'a> UnverifiedAuthnRequest<'a> {
         })
     }
 
-    pub fn get_cert_der(&self) -> Result<Vec<u8>, Error> {
-        let x509_cert = self
+    pub fn get_certs_der(&self) -> Result<Vec<Vec<u8>>, Error> {
+        let x509_certs = self
             .request
             .signature
             .as_ref()
             .ok_or(Error::NoSignature)?
             .key_info
             .as_ref()
-            .map(|ki| ki.iter().next())
+            .map(|ki| ki.iter().next()) // TODO: why only the first key?
             .unwrap_or(None)
             .ok_or(Error::NoKeyInfo)?
             .x509_data
-            .as_ref()
-            .map(|d| d.certificate.as_ref())
-            .unwrap_or(None)
-            .ok_or(Error::NoCertificate)?;
-
-        let x509_cert = crypto::decode_x509_cert(x509_cert.as_str())
+            .iter()
+            .flat_map(|d| d.certificates.iter())
+            .map(|cert| crypto::decode_x509_cert(cert.as_str()))
+            .collect::<Result<Vec<_>, _>>()
             .map_err(|_| Error::InvalidCertificateEncoding)?;
-        Ok(x509_cert)
+
+        if x509_certs.is_empty() {
+            return Err(Error::NoCertificate);
+        }
+
+        Ok(x509_certs)
     }
 
     pub fn try_verify_self_signed(self) -> Result<VerifiedAuthnRequest, Error> {
-        let cert = self.get_cert_der()?;
-        self.try_verify_with_cert(&cert)
+        let xml = self.xml.as_bytes();
+        self.get_certs_der()?
+            .into_iter()
+            .map(|der_cert| Ok(verify_signed_xml(xml, &der_cert, Some("ID"))?))
+            .reduce(|a, b| a.or(b))
+            .unwrap()
+            .map(|()| VerifiedAuthnRequest(self.request))
     }
 
     pub fn try_verify_with_cert(self, der_cert: &[u8]) -> Result<VerifiedAuthnRequest, Error> {

--- a/src/key_info.rs
+++ b/src/key_info.rs
@@ -37,7 +37,7 @@ const X509_DATA_NAME: &str = "ds:X509Data";
 #[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct X509Data {
     #[serde(rename = "X509Certificate")]
-    pub certificate: Option<String>,
+    pub certificates: Vec<String>,
 }
 
 impl X509Data {
@@ -47,7 +47,7 @@ impl X509Data {
         let root = BytesStart::borrowed(X509_DATA_NAME.as_bytes(), X509_DATA_NAME.len());
         writer.write_event(Event::Start(root))?;
 
-        if let Some(certificate) = &self.certificate {
+        for certificate in &self.certificates {
             let name = "ds:X509Certificate";
             writer.write_event(Event::Start(BytesStart::borrowed(
                 name.as_bytes(),

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -64,9 +64,9 @@ impl Signature {
             key_info: Some(vec![KeyInfo {
                 id: None,
                 x509_data: Some(X509Data {
-                    certificate: Some(
+                    certificates: vec![
                         crate::crypto::mime_encode_x509_cert(x509_cert_der)
-                    ),
+                    ],
                 }),
             }]),
         }
@@ -96,7 +96,7 @@ impl Signature {
         self.key_info.get_or_insert(Vec::new()).push(KeyInfo {
             id: None,
             x509_data: Some(X509Data {
-                certificate: Some(base64::encode(public_cert_der)),
+                certificates: vec![base64::encode(public_cert_der)],
             }),
         });
         self


### PR DESCRIPTION
They will be parsed correctly even if they are spread on several lines.

Fix #7 and #11
