### PR TITLE
Make status in responses optional

### DIFF
--- a/src/idp/response_builder.rs
+++ b/src/idp/response_builder.rs
@@ -125,13 +125,13 @@ fn build_response(
         consent: None,
         issuer: Some(issuer.clone()),
         signature: Some(Signature::template(&response_id, x509_cert)),
-        status: Status {
+        status: Some(Status {
             status_code: StatusCode {
                 value: Some("urn:oasis:names:tc:SAML:2.0:status:Success".to_string()),
             },
             status_message: None,
             status_detail: None,
-        },
+        }),
         encrypted_assertion: None,
         assertion: Some(build_assertion(
             name_id,

--- a/src/schema/response.rs
+++ b/src/schema/response.rs
@@ -30,7 +30,7 @@ pub struct Response {
     #[serde(rename = "Signature")]
     pub signature: Option<Signature>,
     #[serde(rename = "Status")]
-    pub status: Status,
+    pub status: Option<Status>,
     #[serde(rename = "EncryptedAssertion")]
     pub encrypted_assertion: Option<String>,
     #[serde(rename = "Assertion")]
@@ -90,8 +90,9 @@ impl Response {
         if let Some(signature) = &self.signature {
             writer.write(signature.to_xml()?.as_bytes())?;
         }
-
-        writer.write(self.status.to_xml()?.as_bytes())?;
+        if let Some(status) = &self.status {
+            writer.write(status.to_xml()?.as_bytes())?;
+        }
 
         if let Some(assertion) = &self.assertion {
             writer.write(assertion.to_xml()?.as_bytes())?;

--- a/src/service_provider.rs
+++ b/src/service_provider.rs
@@ -414,11 +414,13 @@ impl ServiceProvider {
                 });
             }
         }
-        if let Some(status) = &response.status.status_code.value {
-            if status != "urn:oasis:names:tc:SAML:2.0:status:Success" {
-                return Err(Error::ResponseBadStatusCode {
-                    code: status.clone(),
-                });
+        if let Some(status) = &response.status {
+            if let Some(status) = &status.status_code.value {
+                if status != "urn:oasis:names:tc:SAML:2.0:status:Success" {
+                    return Err(Error::ResponseBadStatusCode {
+                        code: status.clone(),
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
We are already only checking the StatusCode if it has a value. So the following was already accepted:
  <samlp:Status><samlp:StatusCode/></samlp:Status>

This commit also accepts the entire Status node not existing in the response.
This occurs if only the Assertion in a SAMLResponse is signed and the reduce_to_signed_xml function removes the unsigned status element.
If this occurs the reduced response will not pass the serialization round-trip due to the now missing Status node being required.