### PR TITLE
 detect static or dynamic API at build time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,15 +91,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "c2-chacha"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-dependencies = [
- "ppv-lite86",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,24 +296,13 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -556,37 +536,14 @@ checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.14",
- "libc",
- "rand_chacha 0.2.1",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
-dependencies = [
- "c2-chacha",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
@@ -596,16 +553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.14",
+ "rand_core",
 ]
 
 [[package]]
@@ -614,16 +562,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.3",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -632,7 +571,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -677,7 +616,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "quick-xml",
- "rand 0.8.4",
+ "rand",
  "serde",
  "snafu",
  "url",
@@ -846,11 +785,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+checksum = "c6d5d669b51467dcf7b2f1a796ce0f955f05f01cafda6c19d6e95f730df29238"
 dependencies = [
- "rand 0.7.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -870,12 +809,6 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cexpr"
@@ -377,9 +377,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.67"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "libloading"
@@ -636,12 +636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.1.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-
-[[package]]
 name = "regex"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,12 +795,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "redox_syscall",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ snafu = "0.6"
 rand = "0.8.4"
 derive_builder = "0.10.2"
 libxml = { version = "0.3.0", optional = true}
-uuid = { version = "0.8.1", features = ["v4"] }
+uuid = { version = ">=0.8.0, <2.0.0", features = [ "v4" ] }
 data-encoding = "2.2.0"
 libc        = {version = "^0.2.66", optional = true}
 lazy_static = {version = "^1.4.0", optional = true}

--- a/src/xmlsec/backend.rs
+++ b/src/xmlsec/backend.rs
@@ -1,0 +1,21 @@
+//!
+//! Abstraction over API differences between dynamic loading and static OpenSSL
+//!
+
+#[cfg(xmlsec_dynamic)]
+use crate::bindings as backend;
+
+#[cfg(xmlsec_static)]
+mod backend {
+    pub use crate::bindings::{
+        xmlSecOpenSSLAppInit as xmlSecCryptoAppInit,
+        xmlSecOpenSSLAppKeyCertLoad as xmlSecCryptoAppKeyCertLoad,
+        xmlSecOpenSSLAppKeyCertLoadMemory as xmlSecCryptoAppKeyCertLoadMemory,
+        xmlSecOpenSSLAppKeyLoad as xmlSecCryptoAppKeyLoad,
+        xmlSecOpenSSLAppKeyLoadMemory as xmlSecCryptoAppKeyLoadMemory,
+        xmlSecOpenSSLAppShutdown as xmlSecCryptoAppShutdown, xmlSecOpenSSLInit as xmlSecCryptoInit,
+        xmlSecOpenSSLShutdown as xmlSecCryptoShutdown,
+    };
+}
+
+pub use backend::*;

--- a/src/xmlsec/error.rs
+++ b/src/xmlsec/error.rs
@@ -9,10 +9,13 @@ pub type XmlSecResult<T> = Result<T, XmlSecError>;
 #[allow(missing_docs)]
 #[derive(Debug)]
 pub enum XmlSecError {
+    XmlSecAbiMismatch,
     XmlSecInitError,
     ContextInitError,
     CryptoInitOpenSSLError,
     CryptoInitOpenSSLAppError,
+    #[cfg(xmlsec_dynamic)]
+    CryptoLoadLibraryError,
 
     InvalidInputString,
 
@@ -33,11 +36,16 @@ impl std::fmt::Display for XmlSecError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::XmlSecInitError => write!(fmt, "{}", "Internal XmlSec Init Error"),
+            Self::XmlSecAbiMismatch => write!(fmt, "{}", "XmlSec ABI version mismatch"),
             Self::CryptoInitOpenSSLError => {
                 write!(fmt, "{}", "Internal XmlSec Crypto OpenSSL Init Error")
             }
             Self::CryptoInitOpenSSLAppError => {
                 write!(fmt, "{}", "Internal XmlSec Crypto OpenSSLApp Init Error")
+            }
+            #[cfg(xmlsec_dynamic)]
+            Self::CryptoLoadLibraryError => {
+                write!(fmt, "{}", "XmlSec failed to load default crypto backend")
             }
             Self::ContextInitError => write!(fmt, "{}", "Internal XmlSec Context Error"),
 

--- a/src/xmlsec/keys.rs
+++ b/src/xmlsec/keys.rs
@@ -6,6 +6,7 @@ use crate::bindings;
 use super::error::XmlSecError;
 use super::error::XmlSecResult;
 use super::xmlsec;
+use super::backend;
 
 use std::ptr::null;
 use std::ptr::null_mut;
@@ -39,7 +40,7 @@ impl XmlSecKey {
 
         // Load key from buffer
         let key = unsafe {
-            bindings::xmlSecOpenSSLAppKeyLoadMemory(
+            backend::xmlSecCryptoAppKeyLoadMemory(
                 buffer.as_ptr(),
                 buffer.len() as u32,
                 format as u32,

--- a/src/xmlsec/mod.rs
+++ b/src/xmlsec/mod.rs
@@ -18,6 +18,7 @@ mod error;
 mod keys;
 mod xmldsig;
 mod xmlsec;
+mod backend;
 
 // exports
 pub use self::error::XmlSecError;


### PR DESCRIPTION
The libxmlsec1 library is available with two similar but incompatible
APIs.  On Debian and Ubuntu systems, the library is built with the
--disable-crypto-dl and --disable-apps-crypto-dl configure options which
results in OpenSSL-specific symbols like xmlSecOpenSSLAppKeyLoad().  On
every other platform I could find, these options are not used, and the
library can dynamically select a backend using symbols like
xmlSecCryptoAppKeyLoad().

The only way this can be detected is examining the CFLAGS we get from
xmlsec1-config.  The XMLSEC_CRYPTO_DYNAMIC_LOADING macro does not appear
to be included in any shipped header file.  The build script now checks
for this definition and uses conditional compilation to substitute
either the OpenSSL-specific static symbols, or the dynamic symbols.