### PR TITLE
handle --enable-size-t in XmlSecKey::from_memory

### DIFF
--- a/src/xmlsec/keys.rs
+++ b/src/xmlsec/keys.rs
@@ -42,7 +42,7 @@ impl XmlSecKey {
         let key = unsafe {
             backend::xmlSecCryptoAppKeyLoadMemory(
                 buffer.as_ptr(),
-                buffer.len() as u32,
+                buffer.len().try_into().expect("Key buffer length overflow"),
                 format as u32,
                 null(),
                 null_mut(),


### PR DESCRIPTION
[xmlsec enabled --enable-size-t by default in 1.3.0](https://www.aleksey.com/xmlsec/news.html), which changes the xmlSecSize typedef to size_t. This changes the `dataSize` parameter in `xmlSecOpenSSLAppKeyLoadMemory` either `usize` or `u32`, depending on the version of xmlsec and the compiler options used by the distribution we happen to build this crate on.

Instead of casting to u32, we can ask the compiler to choose the right conversion for us with `TryInto`, and panic if the conversion would truncate. This does change the behavior of the crate to panic instead of truncate the buffer size if the buffer containing the key is greater than ~4 GB, which I don't think is reasonably possible.

We noticed this because our CI builds on macOS started failing; these builds install libxmlsec1 from Homebrew, which [updated to 1.3.0 last week](https://github.com/Homebrew/homebrew-core/pull/128185).