### PR TITLE
decode_x509_cert: Reset XmlSecSignatureContext for each certificate

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -415,9 +415,9 @@ pub(crate) fn reduce_xml_to_signed(
     {
         let mut signature_nodes = find_signature_nodes(&root_elem);
         for sig_node in signature_nodes.drain(..) {
-            let mut sig_ctx = XmlSecSignatureContext::new()?;
             let mut verified = false;
             for openssl_key in certs {
+                let mut sig_ctx = XmlSecSignatureContext::new()?;
                 let key_data = openssl_key.to_der()?;
                 let key = XmlSecKey::from_memory(&key_data, XmlSecKeyFormat::CertDer)?;
                 sig_ctx.insert_key(key);


### PR DESCRIPTION
When using samael 0.0.13 together with xmlsec 1.2.37 and samltest.id, I encountered the following issue which resulted in a failed signature check (only the second line is relevant here):

```
func=xmlSecOpenSSLEvpSignatureVerify:file=evp_signatures.c:line=453:obj=rsa-sha256:subj=unknown:error=18:data do not match:details=EVP_VerifyFinal: signature verification failed
func=xmlSecDSigCtxProcessSignatureNode:file=xmldsig.c:line=442:obj=unknown:subj=dsigCtx->signValueNode == NULL:error=100:assertion: 
func=xmlSecDSigCtxVerify:file=xmldsig.c:line=352:obj=unknown:subj=xmlSecDSigCtxProcessSignatureNode:error=1:xmlsec library function failed:
```

The issue seems to be that the context is reused in ```decode_x509_cert``` (the assertion only fails when checking against the second certificate). This minor change did fix the issue for me.