### PR TITLE
remove legacy openssl import

### DIFF
--- a/src/xmlsec/backend.rs
+++ b/src/xmlsec/backend.rs
@@ -11,7 +11,6 @@ mod backend {
         xmlSecOpenSSLAppInit as xmlSecCryptoAppInit,
         xmlSecOpenSSLAppKeyCertLoad as xmlSecCryptoAppKeyCertLoad,
         xmlSecOpenSSLAppKeyCertLoadMemory as xmlSecCryptoAppKeyCertLoadMemory,
-        xmlSecOpenSSLAppKeyLoad as xmlSecCryptoAppKeyLoad,
         xmlSecOpenSSLAppKeyLoadMemory as xmlSecCryptoAppKeyLoadMemory,
         xmlSecOpenSSLAppShutdown as xmlSecCryptoAppShutdown, xmlSecOpenSSLInit as xmlSecCryptoInit,
         xmlSecOpenSSLShutdown as xmlSecCryptoShutdown,


### PR DESCRIPTION
`xmlSecCryptoAppKeyLoad` is not actually used in samael. It's inclusion was causing build errors with recent versions of external dependencies.