### PR TITLE
Allow extensions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+- Add ability to serialize and deserialize `Extensions` in an `AuthnRequest`
+
 ### 0.0.15
 
 - Updates dependencies

--- a/src/schema/authn_request.rs
+++ b/src/schema/authn_request.rs
@@ -1,4 +1,4 @@
-use crate::schema::{Conditions, Issuer, NameIdPolicy, Subject};
+use crate::schema::{Conditions, Extensions, Issuer, NameIdPolicy, Subject};
 use crate::signature::Signature;
 use chrono::prelude::*;
 use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
@@ -30,6 +30,8 @@ pub struct AuthnRequest {
     pub issuer: Option<Issuer>,
     #[serde(rename = "Signature")]
     pub signature: Option<Signature>,
+    #[serde(rename = "Extensions")]
+    pub extensions: Option<Extensions>,
     #[serde(rename = "Subject")]
     pub subject: Option<Subject>,
     #[serde(rename = "NameIDPolicy")]
@@ -62,6 +64,7 @@ impl Default for AuthnRequest {
             consent: None,
             issuer: None,
             signature: None,
+            extensions: None,
             subject: None,
             name_id_policy: None,
             conditions: None,
@@ -205,6 +208,10 @@ impl TryFrom<&AuthnRequest> for Event<'_> {
         }
         if let Some(signature) = &value.signature {
             let event: Event<'_> = signature.try_into()?;
+            writer.write_event(event)?;
+        }
+        if let Some(extensions) = &value.extensions {
+            let event: Event<'_> = extensions.try_into()?;
             writer.write_event(event)?;
         }
         if let Some(subject) = &value.subject {

--- a/src/schema/extensions.rs
+++ b/src/schema/extensions.rs
@@ -1,0 +1,56 @@
+use std::io::{Cursor, Write};
+
+use quick_xml::{
+    events::{BytesEnd, BytesStart, BytesText, Event},
+    Writer,
+};
+use serde::Deserialize;
+
+const NAME: &str = "saml2p:Extensions";
+
+#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Extensions(pub Vec<String>);
+
+impl TryFrom<Extensions> for Event<'_> {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(value: Extensions) -> Result<Self, Self::Error> {
+        (&value).try_into()
+    }
+}
+
+impl TryFrom<&Extensions> for Event<'_> {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(value: &Extensions) -> Result<Self, Self::Error> {
+        let mut write_buf = Vec::new();
+        let mut writer = Writer::new(Cursor::new(&mut write_buf));
+        let root = BytesStart::from_content(NAME, NAME.len());
+        writer.write_event(Event::Start(root))?;
+
+        for extension in &value.0 {
+            writer.get_mut().write_all(extension.as_bytes())?;
+        }
+
+        writer.write_event(Event::End(BytesEnd::new(NAME)))?;
+        Ok(Event::Text(BytesText::from_escaped(String::from_utf8(
+            write_buf,
+        )?)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::ToXml;
+
+    #[test]
+    fn extensions_xml_serialization() {
+        assert_eq!(
+            r#"<saml2p:Extensions><qqq a="b"/></saml2p:Extensions>"#,
+            Extensions(vec![r#"<qqq a="b"/>"#.to_string()])
+                .to_xml()
+                .unwrap(),
+        )
+    }
+}

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,5 +1,6 @@
 pub mod authn_request;
 mod conditions;
+mod extensions;
 mod issuer;
 mod name_id_policy;
 mod response;
@@ -7,6 +8,7 @@ mod subject;
 
 pub use authn_request::AuthnRequest;
 pub use conditions::*;
+pub use extensions::Extensions;
 pub use issuer::Issuer;
 pub use name_id_policy::NameIdPolicy;
 pub use response::Response;


### PR DESCRIPTION
This PR implements the `Extensions` struct and adds it to the `AuthnRequest`. This allows to parse or create requests with arbitrary extensions, like this:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<saml2p:AuthnRequest xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" ID="..."
    Version="2.0" IssueInstant="2024-04-10T15:24:12.152Z"
    Destination="..."
    ForceAuthn="false" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
    AssertionConsumerServiceURL="...">
    <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
        Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">https://service-ozg.dev</saml2:Issuer>
    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
        <ds:SignedInfo>
            <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
            <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
            <ds:Reference URI="...">
                <ds:Transforms>
                    <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
                    <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
                </ds:Transforms>
                <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />
                <ds:DigestValue>...</ds:DigestValue>
            </ds:Reference>
        </ds:SignedInfo>
        <ds:SignatureValue>...</ds:SignatureValue>
        <ds:KeyInfo>
            <ds:X509Data>
                <ds:X509Certificate>
                ...
                </ds:X509Certificate>
            </ds:X509Data>
        </ds:KeyInfo>
    </ds:Signature>
    <saml2p:Extensions>
        <example:AuthenticationRequest xmlns:example="https://www.example.com/request/2020/09" Version="2">
            <example:RequestedAttributes>
                <example:RequestedAttribute Name="urn:name1"
                    RequiredAttribute="false" />
                <example:RequestedAttribute Name="urn:name2"
                    RequiredAttribute="false" />
                <example:RequestedAttribute Name="urn:name2"
                    RequiredAttribute="false" />
            </example:RequestedAttributes>
            <example:DisplayInformation>
                <ui:Version  xmlns:ui="https://www.example.com/request/2020/09/ui/v1">
                    <ui:DisplayName>Fancy name</ui:DisplayName>
                </ui:Version>
            </example:DisplayInformation>
        </example:AuthenticationRequest>
    </saml2p:Extensions>
    <saml2p:NameIDPolicy AllowCreate="true" />
</saml2p:AuthnRequest>
```

I am not exactly happy with using a `Vec<String>` as internal data for the `Extensions` struct, which means the user will be responsible to manually de-/serialize whatever extensions are part of the `AuthnRequest` but it's an easy initial implementation.
If this is not satisfactory, then we can later change that to a vector of trait objects or something similar.