### PR TITLE
Do not send NameIDPolicy with a blank Format

### DIFF
--- a/src/service_provider/mod.rs
+++ b/src/service_provider/mod.rs
@@ -236,11 +236,8 @@ impl ServiceProvider {
         self.authn_name_id_format
             .clone()
             .and_then(|v| -> Option<String> {
-                let unspecified = NameIdFormat::UnspecifiedNameIDFormat.value();
                 if v.is_empty() {
                     Some(NameIdFormat::TransientNameIDFormat.value().to_string())
-                } else if v == unspecified {
-                    None
                 } else {
                     Some(v)
                 }
@@ -478,11 +475,13 @@ impl ServiceProvider {
                 value: entity_id,
                 ..Issuer::default()
             }),
-            name_id_policy: Some(NameIdPolicy {
-                allow_create: Some(true),
-                format: self.name_id_format(),
-                ..NameIdPolicy::default()
-            }),
+            name_id_policy: self.name_id_format().map(|format|
+                NameIdPolicy {
+                    allow_create: Some(true),
+                    format: Some(format),
+                    ..NameIdPolicy::default()
+                }
+            ),
             force_authn: Some(self.force_authn),
             ..AuthnRequest::default()
         })

--- a/src/service_provider/mod.rs
+++ b/src/service_provider/mod.rs
@@ -475,13 +475,11 @@ impl ServiceProvider {
                 value: entity_id,
                 ..Issuer::default()
             }),
-            name_id_policy: self.name_id_format().map(|format|
-                NameIdPolicy {
-                    allow_create: Some(true),
-                    format: Some(format),
-                    ..NameIdPolicy::default()
-                }
-            ),
+            name_id_policy: self.name_id_format().map(|format| NameIdPolicy {
+                allow_create: Some(true),
+                format: Some(format),
+                ..NameIdPolicy::default()
+            }),
             force_authn: Some(self.force_authn),
             ..AuthnRequest::default()
         })


### PR DESCRIPTION
Previously, if the `name_id_format` function returned None, this would
cause `NameIdPolicy` to have None as a format, leading to the following
tag in an AuthnRequest:

```xml
<saml2p:NameIDPolicy AllowCreate="true"/>
```

Skip creating a `Some(NameIDPolicy)` if `name_id_format` returns `None`.

Additionally, do not override if `authn_name_id_format` is set to
`Unspecified`: previously this would cause `name_id_format` to return
`None` where a caller explicitly set it to `Unspecified`.