### PR TITLE
Exposed ToXml Traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub mod signature;
 #[cfg(feature = "xmlsec")]
 mod xmlsec;
 
-mod traits;
+pub mod traits;
 
 #[macro_use]
 extern crate derive_builder;


### PR DESCRIPTION
This will enable the developers to use the ```to_xml``` method for serializing to XML
This will be required for sending returning respones from the IdentityProvider.