### PR TITLE
pub use requested attribute

### DIFF
--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -11,7 +11,7 @@ mod organization;
 mod sp_sso_descriptor;
 
 pub use affiliation_descriptor::*;
-pub use attribute_consuming_service::AttributeConsumingService;
+pub use attribute_consuming_service::{AttributeConsumingService, RequestedAttribute};
 pub use contact_person::*;
 pub use encryption_method::EncryptionMethod;
 pub use endpoint::*;


### PR DESCRIPTION
Just needed to reexport the struct RequestedAttribute to build an AttributeConsumingService and append it to my SP metadata.
Not sure If I'm using the library right because of that but it worked for me.