### PR TITLE
Fix Brew Environment Problems

### DIFF
--- a/bindings.rs
+++ b/bindings.rs
@@ -17,6 +17,30 @@ fn main() {
     println!("cargo:rustc-check-cfg=cfg(xmlsec_static)");
 
     if env::var_os("CARGO_FEATURE_XMLSEC").is_some() {
+        let lib = PkgConfig::new()
+            .probe("xmlsec1")
+            .expect("Could not find xmlsec1 using pkg-config");
+
+        // Show what we're using in the build outputpkg-config --modversion xmlsec1
+        println!("cargo:warning=xmlsec1 version: {}", lib.version);
+        for p in &lib.include_paths {
+            println!("cargo:warning=xmlsec1 include path: {}", p.display());
+        }
+        for p in &lib.link_paths {
+            println!("cargo:warning=xmlsec1 link path: {}", p.display());
+            // ensure rustc links against the same directory
+            println!("cargo:rustc-link-search=native={}", p.display());
+        }
+        println!("cargo:warning=xmlsec1 libs: {:?}", lib.libs);
+        println!(
+            "cargo:warning=xmlsec cflags: {}",
+            fetch_xmlsec_config_flags().join(" ")
+        );
+        println!(
+            "cargo:warning=xmlsec libs: {}",
+            fetch_xmlsec_config_libs().join(" ")
+        );
+
         let path_out = PathBuf::from(env::var("OUT_DIR").unwrap());
         let path_bindings = path_out.join(BINDINGS);
 

--- a/src/idp/mod.rs
+++ b/src/idp/mod.rs
@@ -8,6 +8,7 @@ pub mod verified_request;
 #[cfg(test)]
 mod tests;
 
+use chrono::{DateTime, Utc};
 use openssl::bn::{BigNum, MsbOption};
 use openssl::ec::{EcGroup, EcKey};
 use openssl::nid::Nid;
@@ -20,11 +21,11 @@ use crate::crypto::{self};
 use crate::idp::response_builder::{build_response_template, ResponseAttribute};
 use crate::metadata::NameIdFormat;
 use crate::schema::Response;
+use crate::signature::DigestAlgorithm;
 use crate::traits::ToXml;
 
 pub struct IdentityProvider {
     private_key: pkey::PKey<Private>,
-    name_id_format: NameIdFormat,
 }
 
 pub enum Rsa {
@@ -76,20 +77,14 @@ impl IdentityProvider {
             }
         };
 
-        Ok(IdentityProvider {
-            private_key,
-            name_id_format: NameIdFormat::default(),
-        })
+        Ok(IdentityProvider { private_key })
     }
 
     pub fn from_rsa_private_key_der(der_bytes: &[u8]) -> Result<Self, Error> {
         let rsa = openssl::rsa::Rsa::private_key_from_der(der_bytes)?;
         let private_key = pkey::PKey::from_rsa(rsa)?;
 
-        Ok(IdentityProvider {
-            private_key,
-            name_id_format: NameIdFormat::default(),
-        })
+        Ok(IdentityProvider { private_key })
     }
 
     pub fn export_private_key_der(&self) -> Result<Vec<u8>, Error> {
@@ -146,6 +141,7 @@ impl IdentityProvider {
         issuer: &str,
         in_response_to_id: &str,
         attributes: &[ResponseAttribute],
+        optional_arguments: &OptionalSigningArgs,
     ) -> Result<Response, Box<dyn std::error::Error>> {
         let response = build_response_template(
             idp_x509_cert_der,
@@ -155,7 +151,12 @@ impl IdentityProvider {
             acs_url,
             in_response_to_id,
             attributes,
-            &self.name_id_format,
+            &optional_arguments.name_id_format,
+            &optional_arguments.not_before,
+            &optional_arguments.not_on_or_after,
+            &optional_arguments.digest_algorithm,
+            &optional_arguments.destination.as_deref(),
+            &optional_arguments.recipient.as_deref(),
         );
 
         let response_xml_unsigned = response.to_string()?;
@@ -166,18 +167,86 @@ impl IdentityProvider {
         let signed_response = Response::from_str(signed_xml.as_str())?;
         Ok(signed_response)
     }
+}
 
-    /// Change the `NameId` format of the [`IdentityProvider`].
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let idp = IdentityProvider::from_rsa_private_key_der(&der_bytes)?
-    ///     .with_name_id_format(NameIdFormat::EmailAddressNameIDFormat);
-    /// ```
-    pub fn with_name_id_format(mut self, name_id_format: NameIdFormat) -> Self {
-        self.name_id_format = name_id_format;
+/// A set of optional arguments that are not broken out by the default `samael`
+/// crate.
+pub struct OptionalSigningArgs {
+    /// The `NotBefore` field in the `Conditions`. I.e. the response is not
+    /// valid before this time.
+    not_before: Option<DateTime<Utc>>,
 
-        self
+    /// The `NotOnOrAfter` field in the `Conditions`. I.e. the response is not
+    /// valid on or after this time.
+    not_on_or_after: Option<DateTime<Utc>>,
+
+    /// The top-level `Destination` tag. Will use the ACS url if not specified.
+    destination: Option<String>,
+
+    /// The `Recipient` field in the `SubjectConfirmationData`. Will use the ACS
+    /// if not specified.
+    recipient: Option<String>,
+
+    /// Indicates the format used by the `NameId` field.
+    name_id_format: NameIdFormat,
+
+    /// Defines which algorithm should be used to generate the assertion digest.
+    digest_algorithm: DigestAlgorithm,
+}
+
+impl Default for OptionalSigningArgs {
+    fn default() -> Self {
+        Self {
+            not_before: None,
+            not_on_or_after: None,
+            destination: None,
+            recipient: None,
+            name_id_format: NameIdFormat::default(),
+            digest_algorithm: DigestAlgorithm::default(),
+        }
+    }
+}
+
+impl OptionalSigningArgs {
+    pub fn with_not_before(self, not_before: DateTime<Utc>) -> Self {
+        Self {
+            not_before: Some(not_before),
+            ..self
+        }
+    }
+
+    pub fn with_not_on_or_after(self, not_on_or_after: DateTime<Utc>) -> Self {
+        Self {
+            not_on_or_after: Some(not_on_or_after),
+            ..self
+        }
+    }
+
+    pub fn with_destination(self, destination: String) -> Self {
+        Self {
+            destination: Some(destination),
+            ..self
+        }
+    }
+
+    pub fn with_recipient(self, recipient: String) -> Self {
+        Self {
+            recipient: Some(recipient),
+            ..self
+        }
+    }
+
+    pub fn with_name_id_format(self, name_id_format: NameIdFormat) -> Self {
+        Self {
+            name_id_format,
+            ..self
+        }
+    }
+
+    pub fn with_digest_algorithm(self, digest_algorithm: DigestAlgorithm) -> Self {
+        Self {
+            digest_algorithm,
+            ..self
+        }
     }
 }

--- a/src/idp/mod.rs
+++ b/src/idp/mod.rs
@@ -155,8 +155,8 @@ impl IdentityProvider {
             &optional_arguments.not_before,
             &optional_arguments.not_on_or_after,
             &optional_arguments.digest_algorithm,
-            &optional_arguments.destination.as_deref(),
-            &optional_arguments.recipient.as_deref(),
+            &optional_arguments.destination_override.as_deref(),
+            &optional_arguments.recipient_override.as_deref(),
         );
 
         let response_xml_unsigned = response.to_string()?;
@@ -181,11 +181,11 @@ pub struct OptionalSigningArgs {
     not_on_or_after: Option<DateTime<Utc>>,
 
     /// The top-level `Destination` tag. Will use the ACS url if not specified.
-    destination: Option<String>,
+    destination_override: Option<String>,
 
     /// The `Recipient` field in the `SubjectConfirmationData`. Will use the ACS
     /// if not specified.
-    recipient: Option<String>,
+    recipient_override: Option<String>,
 
     /// Indicates the format used by the `NameId` field.
     name_id_format: NameIdFormat,
@@ -199,8 +199,8 @@ impl Default for OptionalSigningArgs {
         Self {
             not_before: None,
             not_on_or_after: None,
-            destination: None,
-            recipient: None,
+            destination_override: None,
+            recipient_override: None,
             name_id_format: NameIdFormat::default(),
             digest_algorithm: DigestAlgorithm::default(),
         }
@@ -222,16 +222,16 @@ impl OptionalSigningArgs {
         }
     }
 
-    pub fn with_destination(self, destination: String) -> Self {
+    pub fn with_destination_override(self, destination_override: String) -> Self {
         Self {
-            destination: Some(destination),
+            destination_override: Some(destination_override),
             ..self
         }
     }
 
-    pub fn with_recipient(self, recipient: String) -> Self {
+    pub fn with_recipient_override(self, recipient_override: String) -> Self {
         Self {
-            recipient: Some(recipient),
+            recipient_override: Some(recipient_override),
             ..self
         }
     }

--- a/src/idp/response_builder.rs
+++ b/src/idp/response_builder.rs
@@ -41,6 +41,7 @@ fn build_authn_statement(class: &str) -> AuthnStatement {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct ResponseAttribute {
     pub required_attribute: RequiredAttribute,
     pub value: String,

--- a/src/idp/response_builder.rs
+++ b/src/idp/response_builder.rs
@@ -1,4 +1,5 @@
 use crate::attribute::{Attribute, AttributeValue};
+use crate::metadata::NameIdFormat;
 use crate::schema::{
     Assertion, AttributeStatement, AudienceRestriction, AuthnContext, AuthnContextClassRef,
     AuthnStatement, Conditions, Issuer, Response, Status, StatusCode, Subject, SubjectConfirmation,
@@ -63,6 +64,7 @@ fn build_assertion(
     recipient: &str,
     audience: &str,
     attributes: &[ResponseAttribute],
+    name_id_format: &NameIdFormat,
 ) -> Assertion {
     let assertion_id = crypto::gen_saml_assertion_id();
 
@@ -74,7 +76,7 @@ fn build_assertion(
         signature: None,
         subject: Some(Subject {
             name_id: Some(SubjectNameID {
-                format: Some("urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified".to_string()),
+                format: Some(name_id_format.value().to_owned()),
                 value: name_id.to_owned(),
             }),
             subject_confirmations: Some(vec![SubjectConfirmation {
@@ -108,6 +110,7 @@ fn build_response(
     destination: &str,
     audience: &str,
     x509_cert: &[u8],
+    name_id_format: &NameIdFormat,
 ) -> Response {
     let issuer = Issuer {
         value: Some(issuer.to_string()),
@@ -140,6 +143,7 @@ fn build_response(
             destination,
             audience,
             attributes,
+            name_id_format,
         )),
     }
 }
@@ -152,8 +156,16 @@ pub fn build_response_template(
     acs_url: &str,
     request_id: &str,
     attributes: &[ResponseAttribute],
+    name_id_format: &NameIdFormat,
 ) -> Response {
     build_response(
-        name_id, issuer, request_id, attributes, acs_url, audience, cert_der,
+        name_id,
+        issuer,
+        request_id,
+        attributes,
+        acs_url,
+        audience,
+        cert_der,
+        name_id_format,
     )
 }

--- a/src/idp/response_builder.rs
+++ b/src/idp/response_builder.rs
@@ -41,9 +41,9 @@ fn build_authn_statement(class: &str) -> AuthnStatement {
     }
 }
 
-pub struct ResponseAttribute<'a> {
+pub struct ResponseAttribute {
     pub required_attribute: RequiredAttribute,
-    pub value: &'a str,
+    pub value: String,
 }
 
 fn build_attributes(formats_names_values: &[ResponseAttribute]) -> Vec<Attribute> {

--- a/src/idp/sp_extractor.rs
+++ b/src/idp/sp_extractor.rs
@@ -4,6 +4,7 @@ use crate::metadata::EntityDescriptor;
 
 pub struct SPMetadataExtractor(EntityDescriptor);
 
+#[derive(Debug, Clone)]
 pub struct RequiredAttribute {
     pub name: String,
     pub format: Option<String>,

--- a/src/idp/tests.rs
+++ b/src/idp/tests.rs
@@ -562,7 +562,7 @@ fn test_that_providing_destination_will_use_that_instead_of_acs() {
             "https://idp.example.com",
             verified.id.as_str(),
             &[],
-            &OptionalSigningArgs::default().with_destination(destination.to_owned()),
+            &OptionalSigningArgs::default().with_destination_override(destination.to_owned()),
         )
         .expect("failed to created and sign response");
 
@@ -617,7 +617,7 @@ fn test_that_providing_recipient_will_use_that_instead_of_destination() {
             "https://idp.example.com",
             verified.id.as_str(),
             &[],
-            &OptionalSigningArgs::default().with_destination(destination.to_owned()),
+            &OptionalSigningArgs::default().with_destination_override(destination.to_owned()),
         )
         .expect("failed to created and sign response");
 
@@ -631,8 +631,8 @@ fn test_that_providing_recipient_will_use_that_instead_of_destination() {
             verified.id.as_str(),
             &[],
             &OptionalSigningArgs::default()
-                .with_destination(destination.to_owned())
-                .with_recipient(recipient.to_owned()),
+                .with_destination_override(destination.to_owned())
+                .with_recipient_override(recipient.to_owned()),
         )
         .expect("failed to created and sign response");
 

--- a/src/idp/tests.rs
+++ b/src/idp/tests.rs
@@ -83,7 +83,7 @@ fn test_signed_response() {
                 name: attr.1.to_string(),
                 format: Some(attr.0.to_string()),
             },
-            value: attr.2,
+            value: attr.2.to_string(),
         })
         .collect::<Vec<ResponseAttribute>>();
 

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -40,8 +40,9 @@ pub const HTTP_POST_BINDING: &str = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-P
 // HTTP_REDIRECT_BINDING is the official URN for the HTTP-Redirect binding (transport)
 pub const HTTP_REDIRECT_BINDING: &str = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect";
 
-#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Default)]
 pub enum NameIdFormat {
+    #[default]
     UnspecifiedNameIDFormat,
     TransientNameIDFormat,
     EmailAddressNameIDFormat,

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -22,7 +22,11 @@ pub struct Signature {
 }
 
 impl Signature {
-    pub fn template(ref_id: &str, x509_cert_der: &[u8]) -> Self {
+    pub fn template(
+        ref_id: &str,
+        x509_cert_der: &[u8],
+        digest_algorithm: &DigestAlgorithm,
+    ) -> Self {
         Signature {
             id: None,
             signed_info: SignedInfo {
@@ -49,7 +53,7 @@ impl Signature {
                         ],
                     }),
                     digest_method: DigestMethod {
-                        algorithm: DigestAlgorithm::Sha1,
+                        algorithm: digest_algorithm.clone(),
                     },
                     digest_value: Some(DigestValue {
                         base64_content: Some("".to_string()),
@@ -448,8 +452,9 @@ impl TryFrom<&DigestMethod> for Event<'_> {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Ord, PartialOrd, Default)]
 pub enum DigestAlgorithm {
+    #[default]
     #[serde(rename = "http://www.w3.org/2000/09/xmldsig#sha1")]
     Sha1,
     #[serde(rename = "http://www.w3.org/2001/04/xmlenc#sha256")]


### PR DESCRIPTION
Issue details captured elsewhere. This MR adds some lines to hardcode the `libxml2` library path to the brew installed location. `pkg-config` was not able to fetch the correct paths due to some internal clobbering of required library paths.