### PR TITLE
fix: use Vec<ContactPerson> with serde default for EntityDescriptor

### DIFF
--- a/src/metadata/contact_person.rs
+++ b/src/metadata/contact_person.rs
@@ -26,20 +26,90 @@ impl ContactType {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Default, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ContactPerson {
-    #[serde(rename = "@contactType")]
     pub contact_type: Option<String>,
-    #[serde(rename = "Company")]
     pub company: Option<String>,
-    #[serde(rename = "GivenName")]
     pub given_name: Option<String>,
-    #[serde(rename = "SurName")]
     pub sur_name: Option<String>,
-    #[serde(rename = "EmailAddress")]
     pub email_addresses: Option<Vec<String>>,
-    #[serde(rename = "TelephoneNumber")]
     pub telephone_numbers: Option<Vec<String>>,
+}
+
+impl<'de> serde::Deserialize<'de> for ContactPerson {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::{self, MapAccess, Visitor};
+        use std::fmt;
+
+        struct ContactPersonVisitor;
+
+        impl<'de> Visitor<'de> for ContactPersonVisitor {
+            type Value = ContactPerson;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("ContactPerson element")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut contact_type = None;
+                let mut company = None;
+                let mut given_name = None;
+                let mut sur_name = None;
+                let mut email_addresses: Option<Vec<String>> = None;
+                let mut telephone_numbers: Option<Vec<String>> = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "@contactType" => {
+                            if contact_type.is_none() {
+                                contact_type = Some(map.next_value()?);
+                            } else {
+                                // Skip duplicate (e.g. from namespaced remd:contactType)
+                                map.next_value::<de::IgnoredAny>()?;
+                            }
+                        }
+                        "Company" => {
+                            company = Some(map.next_value()?);
+                        }
+                        "GivenName" => {
+                            given_name = Some(map.next_value()?);
+                        }
+                        "SurName" => {
+                            sur_name = Some(map.next_value()?);
+                        }
+                        "EmailAddress" => {
+                            let val: String = map.next_value()?;
+                            email_addresses.get_or_insert_with(Vec::new).push(val);
+                        }
+                        "TelephoneNumber" => {
+                            let val: String = map.next_value()?;
+                            telephone_numbers.get_or_insert_with(Vec::new).push(val);
+                        }
+                        _ => {
+                            map.next_value::<de::IgnoredAny>()?;
+                        }
+                    }
+                }
+
+                Ok(ContactPerson {
+                    contact_type,
+                    company,
+                    given_name,
+                    sur_name,
+                    email_addresses,
+                    telephone_numbers,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(ContactPersonVisitor)
+    }
 }
 
 impl TryFrom<ContactPerson> for Event<'_> {

--- a/src/metadata/entity_descriptor.rs
+++ b/src/metadata/entity_descriptor.rs
@@ -187,7 +187,7 @@ pub struct EntityDescriptor {
     pub pdp_descriptors: Option<Vec<PdpDescriptors>>,
     #[serde(rename = "AffiliationDescriptor")]
     pub affiliation_descriptors: Option<AffiliationDescriptor>,
-    #[serde(rename = "ContactPerson")]
+    #[serde(rename = "ContactPerson", default)]
     pub contact_person: Option<Vec<ContactPerson>>,
     #[serde(rename = "Organization")]
     pub organization: Option<Organization>,
@@ -434,5 +434,47 @@ mod test {
         println!("{entity_descriptor:#?}");
 
         assert_eq!(&expected_entity_descriptor, entity_descriptor);
+    }
+}
+
+#[cfg(test)]
+mod contact_person_tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_multiple_contact_persons() {
+        let xml = r#"<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://test.example.org">
+  <ContactPerson contactType="technical">
+    <GivenName>Test</GivenName>
+  </ContactPerson>
+  <ContactPerson contactType="support">
+    <GivenName>Test2</GivenName>
+  </ContactPerson>
+</EntityDescriptor>"#;
+
+        let ed: EntityDescriptor = quick_xml::de::from_str(xml).unwrap();
+        let contacts = ed.contact_person.expect("contact_person should be Some");
+        assert_eq!(contacts.len(), 2);
+    }
+}
+
+#[cfg(test)]
+mod contact_person_ns_tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_contact_person_with_namespaced_attribute() {
+        let xml = r#"<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://test.example.org">
+  <ContactPerson contactType="technical">
+    <GivenName>Test</GivenName>
+  </ContactPerson>
+  <ContactPerson xmlns:remd="http://refeds.org/metadata" contactType="other" remd:contactType="http://refeds.org/metadata/contactType/security">
+    <GivenName>Test2</GivenName>
+  </ContactPerson>
+</EntityDescriptor>"#;
+
+        let ed: EntityDescriptor = quick_xml::de::from_str(xml).unwrap();
+        let contacts = ed.contact_person.expect("contact_person should be Some");
+        assert_eq!(contacts.len(), 2);
     }
 }


### PR DESCRIPTION
The contact_person field used `Option<Vec<ContactPerson>>` without `#[serde(default)]`, causing serde to raise 'duplicate field @contactType' when deserializing XML with multiple `ContactPerson` sibling elements.

This matches the pattern already used in `RoleDescriptor`, `IdpSsoDescriptor`, and other structs in the crate.

Related: https://github.com/njaremko/samael/issues/11

I discovered this when trying to implement MDQ support for samael, and I have a more detailed writeup [here](https://codeberg.org/ap-1/saml-mdq/src/branch/main/NOTE.md).