### PR TITLE
fix: Linux c_char compatibility in xmlsec bindings

### DIFF
--- a/src/crypto/xmlsec/mod.rs
+++ b/src/crypto/xmlsec/mod.rs
@@ -892,7 +892,7 @@ fn node_attribute_names(node: &libxml::tree::Node) -> Vec<AttributeName> {
 
 fn attribute_name_from_ptr(attr_ptr: *mut libxml::bindings::xmlAttr) -> AttributeName {
     unsafe {
-        let local_name = CStr::from_ptr((*attr_ptr).name as *const i8)
+        let local_name = CStr::from_ptr((*attr_ptr).name as *const std::ffi::c_char)
             .to_string_lossy()
             .into_owned();
         let namespace = if (*attr_ptr).ns.is_null() {
@@ -903,7 +903,7 @@ fn attribute_name_from_ptr(attr_ptr: *mut libxml::bindings::xmlAttr) -> Attribut
                 None
             } else {
                 Some(
-                    CStr::from_ptr(href as *const i8)
+                    CStr::from_ptr(href as *const std::ffi::c_char)
                         .to_string_lossy()
                         .into_owned(),
                 )
@@ -958,7 +958,7 @@ fn get_attribute_value(
             return Some(String::new());
         }
 
-        let value = CStr::from_ptr(value_ptr as *const i8)
+        let value = CStr::from_ptr(value_ptr as *const std::ffi::c_char)
             .to_string_lossy()
             .into_owned();
         libc::free(value_ptr as *mut libc::c_void);

--- a/src/crypto/xmlsec/wrapper/xmldsig.rs
+++ b/src/crypto/xmlsec/wrapper/xmldsig.rs
@@ -68,7 +68,8 @@ impl XmlSecSignatureContext {
                 let uri = if ref_ctx.uri.is_null() {
                     None
                 } else {
-                    let uri_cstr = std::ffi::CStr::from_ptr(ref_ctx.uri as *const i8);
+                    let uri_cstr =
+                        std::ffi::CStr::from_ptr(ref_ctx.uri as *const std::ffi::c_char);
                     Some(
                         uri_cstr
                             .to_str()
@@ -84,7 +85,8 @@ impl XmlSecSignatureContext {
 
                 let data_ptr = bindings::xmlSecBufferGetData(predigest_buf);
                 let data_size = bindings::xmlSecBufferGetSize(predigest_buf);
-                let predigest_xml = predigest_xml_from_raw_buffer(data_ptr, data_size)?;
+                let predigest_xml =
+                    predigest_xml_from_raw_buffer(data_ptr, data_size as usize)?;
 
                 result.push(VerifiedReference { uri, predigest_xml });
             }


### PR DESCRIPTION
## Summary

This fixes a Linux portability issue in the `xmlsec` integration that causes `samael` to fail to compile in Docker on Linux targets while still compiling on macOS.

## Problem

The crate used several hard-coded `*const i8` casts when calling `std::ffi::CStr::from_ptr(...)` in the xmlsec/libxml FFI layer.

That works on platforms where `std::ffi::c_char == i8`, but it fails on targets where `c_char` is `u8`. In practice, this broke compilation on Linux ARM in my environment, while the same code still compiled on macOS.

There was also one place where a buffer size coming from xmlsec was passed as `u32` to a helper expecting `usize`, which caused another compilation error.

This was reproduced on `aarch64-unknown-linux-gnu`.

## Fix

This PR makes the FFI code portable by:
- replacing hard-coded `*const i8` casts with `*const std::ffi::c_char`
- converting the xmlsec buffer size to `usize` before passing it to the helper

## Why this is correct

`CStr::from_ptr` expects a pointer to `c_char`, not specifically `i8`. Using `std::ffi::c_char` matches the platform ABI and avoids assuming the signedness of C `char`.

## Files changed

- `src/crypto/xmlsec/wrapper/xmldsig.rs`
- `src/crypto/xmlsec/mod.rs`

## Validation

I verified the crate builds successfully with:

  ```bash
  cargo check