### PR TITLE
feat: support AES-192/256-CBC and AES-192/256-GCM assertion decryption

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@
 - erikescher
 - Guiguiprim
 - iliana
+- jacques-kigo
 - janst97
 - jclulow
 - jmpesp

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Current Features:
       - `http://www.w3.org/2001/04/xmlenc#aes192-cbc`
       - `http://www.w3.org/2001/04/xmlenc#aes256-cbc`
       - `http://www.w3.org/2009/xmlenc11#aes128-gcm`
+      - `http://www.w3.org/2009/xmlenc11#aes192-gcm`
+      - `http://www.w3.org/2009/xmlenc11#aes256-gcm`
 - Verify SAMLRequest (AuthnRequest) message signatures
 - Create signed SAMLResponse (Response) messages
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Current Features:
       - `http://www.w3.org/2001/04/xmlenc#rsa-1_5`
     - **value info:**
       - `http://www.w3.org/2001/04/xmlenc#aes128-cbc`
+      - `http://www.w3.org/2001/04/xmlenc#aes192-cbc`
+      - `http://www.w3.org/2001/04/xmlenc#aes256-cbc`
       - `http://www.w3.org/2009/xmlenc11#aes128-gcm`
 - Verify SAMLRequest (AuthnRequest) message signatures
 - Create signed SAMLResponse (Response) messages

--- a/src/crypto/xmlsec/mod.rs
+++ b/src/crypto/xmlsec/mod.rs
@@ -315,6 +315,34 @@ impl super::CryptoProvider for XmlSec {
                     &encoded_value[data_end..],
                 )?
             }
+            "http://www.w3.org/2009/xmlenc11#aes192-gcm" => {
+                let cipher = Cipher::aes_192_gcm();
+                let iv_len = cipher.iv_len().unwrap();
+                let tag_len = 16usize;
+                let data_end = encoded_value.len() - tag_len;
+                decrypt_aead(
+                    cipher,
+                    decryption_key,
+                    Some(&encoded_value[0..iv_len]),
+                    &[],
+                    &encoded_value[iv_len..data_end],
+                    &encoded_value[data_end..],
+                )?
+            }
+            "http://www.w3.org/2009/xmlenc11#aes256-gcm" => {
+                let cipher = Cipher::aes_256_gcm();
+                let iv_len = cipher.iv_len().unwrap();
+                let tag_len = 16usize;
+                let data_end = encoded_value.len() - tag_len;
+                decrypt_aead(
+                    cipher,
+                    decryption_key,
+                    Some(&encoded_value[0..iv_len]),
+                    &[],
+                    &encoded_value[iv_len..data_end],
+                    &encoded_value[data_end..],
+                )?
+            }
             _ => {
                 return Err(CryptoError::EncryptedAssertionValueMethodUnsupported {
                     method: method.to_string(),

--- a/src/crypto/xmlsec/mod.rs
+++ b/src/crypto/xmlsec/mod.rs
@@ -281,6 +281,26 @@ impl super::CryptoProvider for XmlSec {
                     &encoded_value[iv_len..],
                 )?
             }
+            "http://www.w3.org/2001/04/xmlenc#aes192-cbc" => {
+                let cipher = Cipher::aes_192_cbc();
+                let iv_len = cipher.iv_len().unwrap();
+                decrypt(
+                    cipher,
+                    decryption_key,
+                    Some(&encoded_value[0..iv_len]),
+                    &encoded_value[iv_len..],
+                )?
+            }
+            "http://www.w3.org/2001/04/xmlenc#aes256-cbc" => {
+                let cipher = Cipher::aes_256_cbc();
+                let iv_len = cipher.iv_len().unwrap();
+                decrypt(
+                    cipher,
+                    decryption_key,
+                    Some(&encoded_value[0..iv_len]),
+                    &encoded_value[iv_len..],
+                )?
+            }
             "http://www.w3.org/2009/xmlenc11#aes128-gcm" => {
                 let cipher = Cipher::aes_128_gcm();
                 let iv_len = cipher.iv_len().unwrap();

--- a/src/service_provider/tests.rs
+++ b/src/service_provider/tests.rs
@@ -306,6 +306,94 @@ mod encrypted_assertion_tests {
         assert!(result.is_ok());
     }
 
+    #[test]
+    fn test_decrypt_assertion_aes192_gcm() {
+        let pkey = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/sp_private.pem"
+        ));
+        let key = PKey::private_key_from_pem(pkey).unwrap();
+
+        let response_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/response_encrypted_aes192_gcm.xml"
+        ));
+        let sp = create_sp_with_private_key_for_response(response_xml, key);
+
+        let response: crate::schema::Response = response_xml.parse().unwrap();
+        assert!(response.encrypted_assertion.is_some());
+
+        let result = response
+            .encrypted_assertion
+            .unwrap()
+            .decrypt(&sp.key.unwrap());
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_decrypt_assertion_aes256_gcm() {
+        let pkey = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/sp_private.pem"
+        ));
+        let key = PKey::private_key_from_pem(pkey).unwrap();
+
+        let response_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/response_encrypted_aes256_gcm.xml"
+        ));
+        let sp = create_sp_with_private_key_for_response(response_xml, key);
+
+        let response: crate::schema::Response = response_xml.parse().unwrap();
+        assert!(response.encrypted_assertion.is_some());
+
+        let result = response
+            .encrypted_assertion
+            .unwrap()
+            .decrypt(&sp.key.unwrap());
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_decrypt_and_validate_assertion_aes192_gcm() {
+        let pkey = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/sp_private.pem"
+        ));
+        let key = PKey::private_key_from_pem(pkey).unwrap();
+
+        let response_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/response_encrypted_valid_aes192_gcm.xml"
+        ));
+        let sp = create_sp_with_private_key_for_response(response_xml, key);
+
+        let result = sp.parse_xml_response(response_xml, Some(&["example"]));
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_decrypt_and_validate_assertion_aes256_gcm() {
+        let pkey = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/sp_private.pem"
+        ));
+        let key = PKey::private_key_from_pem(pkey).unwrap();
+
+        let response_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/response_encrypted_valid_aes256_gcm.xml"
+        ));
+        let sp = create_sp_with_private_key_for_response(response_xml, key);
+
+        let result = sp.parse_xml_response(response_xml, Some(&["example"]));
+
+        assert!(result.is_ok());
+    }
+
     fn extract_first_certificate(xml: &str) -> String {
         let start = xml
             .find("<ds:X509Certificate>")

--- a/src/service_provider/tests.rs
+++ b/src/service_provider/tests.rs
@@ -218,6 +218,94 @@ mod encrypted_assertion_tests {
         assert!(result.is_ok());
     }
 
+    #[test]
+    fn test_decrypt_assertion_aes192_cbc() {
+        let pkey = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/sp_private.pem"
+        ));
+        let key = PKey::private_key_from_pem(pkey).unwrap();
+
+        let response_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/response_encrypted_aes192_cbc.xml"
+        ));
+        let sp = create_sp_with_private_key_for_response(response_xml, key);
+
+        let response: crate::schema::Response = response_xml.parse().unwrap();
+        assert!(response.encrypted_assertion.is_some());
+
+        let result = response
+            .encrypted_assertion
+            .unwrap()
+            .decrypt(&sp.key.unwrap());
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_decrypt_assertion_aes256_cbc() {
+        let pkey = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/sp_private.pem"
+        ));
+        let key = PKey::private_key_from_pem(pkey).unwrap();
+
+        let response_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/response_encrypted_aes256_cbc.xml"
+        ));
+        let sp = create_sp_with_private_key_for_response(response_xml, key);
+
+        let response: crate::schema::Response = response_xml.parse().unwrap();
+        assert!(response.encrypted_assertion.is_some());
+
+        let result = response
+            .encrypted_assertion
+            .unwrap()
+            .decrypt(&sp.key.unwrap());
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_decrypt_and_validate_assertion_aes192_cbc() {
+        let pkey = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/sp_private.pem"
+        ));
+        let key = PKey::private_key_from_pem(pkey).unwrap();
+
+        let response_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/response_encrypted_valid_aes192_cbc.xml"
+        ));
+        let sp = create_sp_with_private_key_for_response(response_xml, key);
+
+        let result = sp.parse_xml_response(response_xml, Some(&["example"]));
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_decrypt_and_validate_assertion_aes256_cbc() {
+        let pkey = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/sp_private.pem"
+        ));
+        let key = PKey::private_key_from_pem(pkey).unwrap();
+
+        let response_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/response_encrypted_valid_aes256_cbc.xml"
+        ));
+        let sp = create_sp_with_private_key_for_response(response_xml, key);
+
+        let result = sp.parse_xml_response(response_xml, Some(&["example"]));
+
+        assert!(result.is_ok());
+    }
+
     fn extract_first_certificate(xml: &str) -> String {
         let start = xml
             .find("<ds:X509Certificate>")

--- a/test_vectors/README.md
+++ b/test_vectors/README.md
@@ -48,3 +48,54 @@ openssl x509 -in ec_cert.pem -outform DER -out ec_cert.der
 # Step 5: Use the Private Key and Certificate with xmlsec1
 xmlsec1 --sign --privkey-der ec_private.der,ec_cert.der --output response_signed_by_idp_ecdsa.xml --id-attr:ID Response response_signed_template.xml
 ```
+
+# Generating encrypted responses for tests
+
+The `response_encrypted_aes{192,256}_cbc.xml` and `response_encrypted_valid_aes{192,256}_cbc.xml` fixtures are generated with `xmlsec1 --encrypt`, using the existing `sp_cert.pem` / `sp_private.pem` keypair (rsa-oaep-mgf1p key transport).
+
+Step 1 — extract the plaintext assertion from the existing AES-128-CBC fixture (the `<xenc:EncryptedData>` element is self-contained namespace-wise, so it can be passed directly to `xmlsec1 --decrypt`):
+
+```bash
+# Extract the inner <xenc:EncryptedData> element to a standalone file.
+python3 -c "
+import re
+with open('response_encrypted_valid.xml') as f:
+    print(re.search(r'<xenc:EncryptedData.*?</xenc:EncryptedData>', f.read(), re.DOTALL).group(0))
+" > /tmp/encrypted_data.xml
+
+# Decrypt it to obtain the plaintext <saml:Assertion>.
+xmlsec1 --decrypt --lax-key-search --privkey-pem sp_private.pem,sp_cert.pem /tmp/encrypted_data.xml \
+    | tail -n +2 > /tmp/plaintext_assertion.xml
+```
+
+Step 2 — create an encryption template per algorithm. Example for AES-256-CBC (substitute `aes192-cbc` for the AES-192-CBC variant):
+
+```xml
+<xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element">
+    <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+    <dsig:KeyInfo>
+        <xenc:EncryptedKey>
+            <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+            <xenc:CipherData>
+                <xenc:CipherValue/>
+            </xenc:CipherData>
+        </xenc:EncryptedKey>
+    </dsig:KeyInfo>
+    <xenc:CipherData>
+        <xenc:CipherValue/>
+    </xenc:CipherData>
+</xenc:EncryptedData>
+```
+
+Step 3 — encrypt the plaintext with `xmlsec1 --encrypt`, generating a fresh AES session key wrapped with rsa-oaep-mgf1p:
+
+```bash
+xmlsec1 --encrypt --lax-key-search \
+    --pubkey-cert-pem sp_cert.pem \
+    --session-key aes-256 \
+    --xml-data /tmp/plaintext_assertion.xml \
+    --output /tmp/encrypted_data_aes256_cbc.xml \
+    template_aes256_cbc.xml
+```
+
+Step 4 — wrap the resulting `<xenc:EncryptedData>` in a `<samlp:Response>` envelope (mirroring `response_encrypted.xml` / `response_encrypted_valid.xml`). When inlining the encrypted block, restore `xmlns:dsig="http://www.w3.org/2000/09/xmldsig#"` on the `<dsig:KeyInfo>` element — `xmlsec1` strips the redundant namespace declaration since the prefix is already in scope from the parent, but samael's serde-based parser requires the explicit attribute on the element itself (see `EncryptedKeyInfo.ds` in `src/key_info.rs`).

--- a/test_vectors/README.md
+++ b/test_vectors/README.md
@@ -51,7 +51,7 @@ xmlsec1 --sign --privkey-der ec_private.der,ec_cert.der --output response_signed
 
 # Generating encrypted responses for tests
 
-The `response_encrypted_aes{192,256}_cbc.xml` and `response_encrypted_valid_aes{192,256}_cbc.xml` fixtures are generated with `xmlsec1 --encrypt`, using the existing `sp_cert.pem` / `sp_private.pem` keypair (rsa-oaep-mgf1p key transport).
+The `response_encrypted_aes{192,256}_{cbc,gcm}.xml` and `response_encrypted_valid_aes{192,256}_{cbc,gcm}.xml` fixtures are generated with `xmlsec1 --encrypt`, using the existing `sp_cert.pem` / `sp_private.pem` keypair (rsa-oaep-mgf1p key transport).
 
 Step 1 — extract the plaintext assertion from the existing AES-128-CBC fixture (the `<xenc:EncryptedData>` element is self-contained namespace-wise, so it can be passed directly to `xmlsec1 --decrypt`):
 
@@ -68,7 +68,7 @@ xmlsec1 --decrypt --lax-key-search --privkey-pem sp_private.pem,sp_cert.pem /tmp
     | tail -n +2 > /tmp/plaintext_assertion.xml
 ```
 
-Step 2 — create an encryption template per algorithm. Example for AES-256-CBC (substitute `aes192-cbc` for the AES-192-CBC variant):
+Step 2 — create an encryption template per algorithm. Example for AES-256-CBC (substitute `aes192-cbc` for the AES-192-CBC variant, or use the `xmlenc11` namespace and `aes{192,256}-gcm` for GCM):
 
 ```xml
 <xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element">

--- a/test_vectors/response_encrypted_aes192_cbc.xml
+++ b/test_vectors/response_encrypted_aes192_cbc.xml
@@ -1,0 +1,46 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_aes192_cbc_encrypted_response" InResponseTo="example" Version="2.0" IssueInstant="2025-03-04T21:09:01.566Z" Destination="http://localhost:8080/saml/acs">
+    <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">saml-mock</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+    
+<saml:EncryptedAssertion><xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element">
+    <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes192-cbc"/>
+    <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+        <xenc:EncryptedKey>
+            <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+            <xenc:CipherData>
+                <xenc:CipherValue>lrc3O8uSApl9LMbrkEzSptFy3NSmnhuRp4FEpLgkqUAqDcC+IBs9H0Eo880joXJp
+SJ1yspvzGxEJHZENSxKqC4uJnKORKrbEtwGG3uGQRwoyCcgQcxW6QK4DK4YBF+1e
+H6GNKuGhc21K2cQIcT+JP1byidkpk7fIDRIZXxr97bU=</xenc:CipherValue>
+            </xenc:CipherData>
+        </xenc:EncryptedKey>
+    </dsig:KeyInfo>
+    <xenc:CipherData>
+        <xenc:CipherValue>u4VhWKJ2qeI1EidISwhS5qh0Y3nt4utLmFpzbYjto5m4dlmt45jfAH9uGdOeJb6k
+EB6kzEzle7zKvpitnYwqp9NAWDEWG9uEtx+jOX4WA55Yd1G6DWwr+HUar/zMpFX1
+tV8aK9rN+0iVFS7Io3LDrlskxPyuH2amynAXm6ZOwVkOWvs0u3bluw9cPPYIp49Y
+Ep11g6bVdEa+HvHDTy3lcBiDdzILMQTVP5CY7Afoh8VRXhcz5uEj20VPKPI/79KJ
+thhtfTXOweYSTqYKFypT7x3J14d0IcN9R03a0Kkcpn/zCega6VaFk0eMESqHfF/y
+mLSskFtkS0bqxoy8F4Kho+blSvsTVwpcRQ9h9V+Ypwk1aCak3DFdA1ESlKNew+W2
+1hg3LFfEhJpqize893V9u07/CP9Zc+RrinIqBICjbKpu9sdHCwECOzWf8KtdpLS/
+F/ZHC8OFwOPOZWrvQ/EXbYQqAC8wSeKSaAEVB5rz/juRBcBvdxatjbqxth5YU/IA
+qw7gl5y2hTusnK6OEs6wBky3VdmfNxiA06KHR8NMvPmoRf06csnyVMes6wKIS3ie
+Xn4gNp1/VSi2ViJrW8eRPB9c91LNgX18kUaN1g6L2cN53tfSbClEYb9CFL2199qC
+d+zwFNtA5GNO7tu1faKoC45Q3GpL3uI/CZ2YWJytq4vVojDyFm2lqvYDZAXKw8e4
+ylAKhL+ZoZ8DpE5qvHAUkZ7PLJ5CSBt2NEj68Zmx5HFuimpcVgQO1j2Kh66AQnYx
+DS5Cs3tcl+u3wsYQ2vZ9QOcb2cp/7Hneva6Znj8nSIlMIhNGGCEU0FEn1pi6ylG0
+0mLrk9TubU9NeuVdMRa1fpDvCWRjalkl93DbJfexWuNtTcYS5ghXiwH5NigsDAYO
+1C3nKzPTXPaI5AzDUaAQFZz+r2jQv8wz1icoepISqVTNPQeirGBlfEZFCwBRmR/k
+r4vjj+bIIZ6ZpH5luERpE7cudK9dIq2b1OkpDhhNMqHUWD6Ivszfl2upTCl2zcaX
+9Lyr+9olKglI6YwJGNfhTBmnRKyqs0tbcJ1SH69o7p0eAlul5o5PlOPEyOROxIa8
+OpbsGdiVcuImJOuhVySX0dQdjUdZnrdEJwCWbPY/DtiwBRh6xcQDQdqQlRvwMv1s
+ut/jUTnCUKu7gOpr4yC7WlBTnNlNGUGzdRrAWqu8qPXlThQbEciIx8/danF2YE/D
+gjcNxTMxgfiWkGRkNFZBt9wVPV7uhxs9T4zhaEXq1n/cy52lLOfw13DKf0lfh4p6
+21nu3s2YI3sF8CCKHENwhbIKcMKyTsL8thZbxLKUzmbK/EXATR42UjjNUZBcgFMc
+F8OobSYXivrOmFXZe1wa9xssVMxdrrWHVO2gTVxY1bJkJj38CdjB1Dip/z30vftP
+ftHiCb7xrEljFnNYbKr6EQ/lyRe9bI7r3jwgsE3E+dGrtVgvVkmLnTM0FKU1sAuM
+NIcvkz0k9aXF0nZa3IE+pEQ7P4EyUbFH3NNP9O0nGzu0CcjhkO8JeiK9L+10fvs/
+55nOt6wICN/+wcTMeDR1mjcJwMZXf0FmMixYkm45M+I2ytCqtyhUcRFLDPa91ay3</xenc:CipherValue>
+    </xenc:CipherData>
+</xenc:EncryptedData></saml:EncryptedAssertion></samlp:Response>

--- a/test_vectors/response_encrypted_aes192_gcm.xml
+++ b/test_vectors/response_encrypted_aes192_gcm.xml
@@ -1,0 +1,46 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_aes192_gcm_encrypted_response" InResponseTo="example" Version="2.0" IssueInstant="2025-03-04T21:09:01.566Z" Destination="http://localhost:8080/saml/acs">
+    <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">saml-mock</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+    
+<saml:EncryptedAssertion><xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:xenc11="http://www.w3.org/2009/xmlenc11#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element">
+    <xenc:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes192-gcm"/>
+    <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+        <xenc:EncryptedKey>
+            <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+            <xenc:CipherData>
+                <xenc:CipherValue>gWYTpB1ZNMd57076IICdFvdkYEly2y+qvZxmZ34DrA3QIjHUhLtjGn5WNekf9KEt
+ubEcseYn3vJpS2NkIFejjaJbvd+IYowTugz6RKAXwuVa1ODeeP8bCHzZ7zQKEpbg
+Tbm7hVhqXU2BeU9EO0Q2A6yn9xvhMkG+fY7OlcErJ70=</xenc:CipherValue>
+            </xenc:CipherData>
+        </xenc:EncryptedKey>
+    </dsig:KeyInfo>
+    <xenc:CipherData>
+        <xenc:CipherValue>HwwPnzS0bHSeA6+dJkUiRvmQVxBX3FVZCv9ZvUVXcElOv0PK42daJEv+NRFez5qJ
+xP3s3pBReP9ARbe/eF9SscMK/sqHtZigXHQcFXX2iG8472MYU0/mCXfm9QkMfwNu
+6XxLMZPJENcYBekTI1jbhS/a0zPzyGepXTULULyFQaDd2mMsQuZKLcDx1QzAWULw
+mFjL0oiEKKQnhBUoPZyNIW6rFPv8gGfARY/BEGhzE570VY/TuUWs+Jtp6jTZC+5G
+hSg7h/35xzfy1NqptGX+2NVJ3xq1x420y+iRy7/EDrvgYdjAZn8IGLhOYZuMBOmF
+/Cddm9nFknfMc70/ftuin8vWE0rIXNUA+irc/XN6Y0IGOvD05/IcHjrNlao6QyKp
+ndepGy7UbbZtptH1BUaDClAGfJvI3NtDmVn6i2nqOP8tr2BhPeKUMADwLObh/JUN
+XKtW603nrS+Ximu7VhrVBtz6q3msndZPXwVC2vYkIX0L09GMcmo2o83QWWNxzUk4
+fN8Y7Z0stFrAvfGMrr7NCrHrjFyx6dmwudtEuMdSqykmVgI3oREtG7eBBXFLC+nq
+obayroMPvtPETCgxzRcNc99DRuEpILA0GrN7NF9dk7qy7LOplvVT8P1i5sa//j8R
+xetOTKEIOWx0KrPiWCao1CVRffTKL7QNtUDUL1u1D8cuUTD/ELLmGVhu4/ngtj4O
+Apo67hXXJFm/RsE/Rx9tP78XrUbkUc5AAqWMnTe8I2L6ao3BRN/hsBEB0n5IYVGe
+KzBUHtP3dF3lnc0m+2Sy50GJTyfTh1MDHATK8x2/W2ab9//rrk8yywN6GvexRfXp
+kY4ha0iKDdhoTspAWpZi/oqqkn+lPHSnXk1zwK/H92aB2/IEHdb4mg8I7esAboRz
+ByYQynKOSlz2AhH1XCPhAhFJJOPb0I2wHFqCrMo4MYWH6uSA6rhrew4yqAVmXGIi
++tTc3Zzv2ggdNAnkvDJS81CCjZ6DcYvdDGSNeZCvnn7E56U48/s4w9P3kYM8dBaT
+YOfi8EkLOHB8EynDAQvdTHgYufWRymxsR3nP3ChoxIcUQKXfeed7bWWWyPYzTJUn
+YEIg7jjdcD7vYszwRfqEyYuA77+MdRo/0JgiZZVUg5wi/PtMvn0g2EKcLqTJ7CSD
+/sEdedc1vio3mclchhgVfMR3di/nb3ODN9oj+vvd7ajmYH8YJ9PhOEh4eEHjzmxl
+ykx/hr4rz+8NC+dfZi2AbLcWUDIH6J2BtVpK24G+SR4r5A5xp5BTD4pT5EcVIaWx
+Vdp1fV8RJYsxupClMOkMW/A5Qc+jlDse28faYaVjdiMVcmRKe9fX3HX0E8Sxzrxa
+kaBCnr4LPS3XUgGHGtvFDGcBZGTqo8OwlQLMhw1pd3qj7Dk76a9DO33rv/wpQLGX
+x3N52cQSemAndjfFJY73HhPBfyseXHdROhD4qYG9YuSZL8y2/5nXdGom0RaPzprY
+bWkGe8amP++WR8quO/3h1qvI44ktBjp/M4rIL702ENtJ2steuOz9YYFrkcDfdBwt
+a1+jnXtYsnTO9eiIrAa8kK3jZNQBSjV9E5IgfEIvTcis/C6381ONhDN9VURX7A==</xenc:CipherValue>
+    </xenc:CipherData>
+</xenc:EncryptedData></saml:EncryptedAssertion></samlp:Response>

--- a/test_vectors/response_encrypted_aes256_cbc.xml
+++ b/test_vectors/response_encrypted_aes256_cbc.xml
@@ -1,0 +1,46 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_aes256_cbc_encrypted_response" InResponseTo="example" Version="2.0" IssueInstant="2025-03-04T21:09:01.566Z" Destination="http://localhost:8080/saml/acs">
+    <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">saml-mock</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+    
+<saml:EncryptedAssertion><xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element">
+    <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+    <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+        <xenc:EncryptedKey>
+            <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+            <xenc:CipherData>
+                <xenc:CipherValue>UvkjKEefKG4OnRqg6FY4rhwSTk1c+imic/t5CgBFmyFuySNOI8JR+9pTZIET8t9N
+O8SFm2vb5ooenLDSc+5pkPCAXf/u3+uB7bmu9yiQubptN6839d4O4oMQp0lSq81k
+SY1OjkFeJHb3arQJEgZ0WBYby4DcSqJQofWiTzWXQko=</xenc:CipherValue>
+            </xenc:CipherData>
+        </xenc:EncryptedKey>
+    </dsig:KeyInfo>
+    <xenc:CipherData>
+        <xenc:CipherValue>eEWkXjo6DJDp/2Pfp3gnwwQ/urtkgoSUkVy36qP+dhvDEpTCse7zIywp8MkLXy2m
+9pNo5d29hjInmaYUlHSmQSemllXUZInnXIk7zGHAVQpPHp5qZPgGABMe6L3eobkU
+ILJ93I9oNUCS8Tl83teY50WusLxXZ5gJ9ba3id+APTzgwht78pY8P0R3FI6PKAaq
+qEQekEbgqPux95a85+NGnQCY7MNbxM+yP5KUne7VU42W7EYWC67vTH6lYyjZN4NX
+OmfLu+1iHBbhp7TQl2hzRVJ+ydcXgS1dlWmYimsEnFZbwHo5j903wUXCMYjxSBJE
+fJWjwbHOzo5cR3NETCgy5WOQsrG0U8zpyJkBXN7MbSY15W5RTVQ/Bykb6GvK/OPb
+B1BlwK/m6PT8iYscwv2yIbBpVUMHaGP2KJF2+FTRHKk3qntLbv7RMjszxb2T4GW1
+NXsFYKoIEc3BLwj/m5B0uov+8M/GizqbwnvewbTGYUk9lz1mbPruypnbsCo5+wMD
+PyaxKkTefjSxkabIp8hn++as9Og2JKK54IuoLJpgNP5KYv32qTPyuU+6ThCw5F75
+OD8ck42fCfJ4q+p2kQUMOVn0BkC51RxPunQ7iFYSGH0zIYWFguiu9b11VQ3SSdWI
+tTlUTnGJyyEqF2uPujuOxELCqINaj3RSKIWSETeMNaSpq9V8qFeKoq4jX/54VQM3
+kNje2DCtU/fORgeh2vL17qlNUK6ov0TnhJoBg1sZSexzMLtCQWrBqYZoorX3oj7l
+y3/he76X32fvyYw9RLuDoeSF3EdyK44QaHvfWVO9u0/wZ1dwq74FYBX6mOBjxooa
+xiiakKhPq2+9c0m7kwE414q0ZlN/ECqM8nFaeDJ1H/SSpGu/IPns920yiRy0kH6p
+1vceNrpxuOx6FRrupAmp6Kv+ARQ0YQgOta5OQDGtlkeSnPhfqdcPGO8gCU9WLb7Y
+Ewy5PJ35BquduOS8Z4iAf66Vp0u/ILpZU230FI7axr1xKqfSaz+QjWL/YSnqYeFI
+9QMlYq7YzjmLZg0hOxGeI2wsUB/xZNJUBOwwsmTMpgME+JO6dXWAOu574XJS0ulH
+kSE3CVznEt+cJOzsePSoq4MYc61qtU7dVNiFdbirKEb+nrIWv/V0Uhc+VeRCrspP
+UWG2B8nKGxSUDniRmWrsxIUB/aj/BToi8lRsOb+zec69azNe+zAyyXEg1YHbPmJs
+yu4GTA9A3VRMzP8K5Fld/dqbo4+0vE4Qx4ohePtOuCSn21QsvdkNGte+Ckrlen0v
+9do+61C7MwkS93JgsjsRwb5ruwYrf0lzg8JULZkg+0rwPzYHohKCgU+ERksKB9Cb
+PmBs46Mkklm2vppauj9R6DwfvnSfrAZ9ughWGy/Rp2ZqAQrfW6lnt4oxy6C2ADR7
+A53zZABVG7U7Vx67RWR2f1sKshbQEdsL3iua/3xANss9j2ljzd1A1Uu8CsRJGPSK
+JfurSRlUgrF0DCKTPxleqz2vFD1fOrUssh/ePpdxnO7S/ejlJlk5jGzHvVLfJfjv
+mfOwZtP5qt/hbi3W0AH4d9rfLGEkcK9ShdJ6tqHnTj0x53VDLz62OOYQ2OYD/z3p</xenc:CipherValue>
+    </xenc:CipherData>
+</xenc:EncryptedData></saml:EncryptedAssertion></samlp:Response>

--- a/test_vectors/response_encrypted_aes256_gcm.xml
+++ b/test_vectors/response_encrypted_aes256_gcm.xml
@@ -1,0 +1,46 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_aes256_gcm_encrypted_response" InResponseTo="example" Version="2.0" IssueInstant="2025-03-04T21:09:01.566Z" Destination="http://localhost:8080/saml/acs">
+    <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">saml-mock</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+    
+<saml:EncryptedAssertion><xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:xenc11="http://www.w3.org/2009/xmlenc11#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element">
+    <xenc:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes256-gcm"/>
+    <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+        <xenc:EncryptedKey>
+            <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+            <xenc:CipherData>
+                <xenc:CipherValue>bGcDkuXRVyqMffXbfPP8EL6JIi/1YbkH1+PbMk4z4pB4ZOkbDczQnu79hTUdiJoD
+ZlJILFTe2knQacavsNlVvqoQNMmIbaiU0oPvcBlM5q65PSKrb3MUjJSYGmEj72m3
+sGVUgK5tA2xeVsiljhoj17bwzlOapGrfOwvoz+5GDcw=</xenc:CipherValue>
+            </xenc:CipherData>
+        </xenc:EncryptedKey>
+    </dsig:KeyInfo>
+    <xenc:CipherData>
+        <xenc:CipherValue>HDXxcHbxAlc71NNyRfpZyNCmGSchxBLYB5nG/vkA9xv54u/CVjw6NzqbFn2ln0ym
+N6OnPvQmbE9SZbQ4HYSblzkNuSW/1jZQRRvBu6BwJ8OnUvhxmvwZhrZdnA2mnvGb
++Kqn+3oLlr2fq5REx9n2XO5y1L8K6aAoga75jzbQ+EjEsOTvo5OQZ56oH1iVVNt1
+/iTkePlFxbqHRvhz30jD3fpRuLzflZRlJvEai+ayh9ztJZJc7A7iIAVmvqEhTjtu
+bvFcEqn+coVElTU8CcInfXEQC+6OWs2UxGbDCSxf4154FKhx3ocL9BYsTQucksX7
+H6bVJGbQlhErxCvWzGvViXGSI5ZgvlJh6Pa+0/W83+lWbrxYTGI+tpQvS+PWJ5H4
+3mWHm2ninKOQ5bIf54TaVwYb8KTqQrt9MBiyJPuCClJo+zgwlczg5XjvOZtjC72d
+jNdIGcZRGEJFlYX1zjNx22EKQhj3P0hHibnNkxhFgcq0+r6oiNk2M6CN+bz2gaGY
+HKfzWp5CV591HZ0vdAMCJiIBplZjPnLUb6Jhb2gZMcpIR5aoEOa7slf2eMLLr4MJ
+OXHtNX9rAxQaxg0qji7Q+i2oH4CemcZGRJkKHywhWLyETIzPHm4CJ6nHi4Q5962v
+qdTUtxXhty9uBUK7jIUujy8fsmmnqIxBqRmMnxEiGSHMch8hXKXnj7SpDBteUkGb
+k1NKNMD4I28mo+BBWFZBKwSoJNmVva/DrZuvwVENz/ut6BlGHWwt6vQX1WsSwvDx
+h40DRLcbZ+asrxHJYiFB+eH9RF6iiEvJTghUGSYgKEemv1InWvIY+QlYtiI8e0Km
+sA/vD2tBMCCPikLknXYtZVYZwavr8kXrFAg0SNvqkmZLfHkF9ZmBrS3Lw4sj3vv+
+SGIM6v0GQN8LD15VS227qsul+3tD6WnpM+L10LcQiGI+mV0gafZMQraHdWhu8BbM
+pFBMQ5CwVfd4IM1gLwG2PxtjPcg7FqpdvGgpKQW4km4RLYKaNaiwHTRtX/Ebsnox
+27JyUXlQaH2n5xlCcHkS7XOwjPjOav3Qy6o4+JVboB3bFoYWQQ4cIaSTvQXFIz/d
+0G3/V5KqL7yFNpmPeMWxS/Z8n6tWD5Dpg/pRVvq/OZOhxduwZJCkL7OyXwfsEgeY
+hjUpq2bHwhwSo7Mal39PVwfmB+Zjx3L1PDgwqklOdV/xVsrjJ5p6n5QIXIRHuzU0
+SotCTK/bNDj1ylVxj73bnDa/DOtIcqPQ+lqR1NNgWasRZGadeeKKAU9232Io0HHe
+XOoLATHwnXW4YqekbNCxnsxdl3SXEXfOXJZE/e1cskJxLmUJVGImjJwHhy3UfQ/O
+eldT2ICzko9JYvsOpIF37FnaQuwhOhZVzO/7C0qrBoNcvxDk3iEEtIWjlJt5URhk
+aIrpSbMmTfubwsbV5GwC4+rM839FWnrxkiEO6UJF4iiVifnr/3Yxi3ySBauwEySW
+4D5Iw1vqWxuRNiREHWTNC4accRuaAAiZfjPhm4K1kAlqckD6yasc8U0YvZTonpH0
+nGeO26LSTT41tuBQ/zUtdtGYx3RMylWXPu86EHT54UIQ7+ppZaRKsGJckmGZSw==</xenc:CipherValue>
+    </xenc:CipherData>
+</xenc:EncryptedData></saml:EncryptedAssertion></samlp:Response>

--- a/test_vectors/response_encrypted_valid_aes192_cbc.xml
+++ b/test_vectors/response_encrypted_valid_aes192_cbc.xml
@@ -1,0 +1,45 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_valid_aes192_cbc_encrypted_response" InResponseTo="example" Version="2.0" IssueInstant="2025-03-04T21:09:01.566Z" Destination="http://localhost:8080/saml/acs">
+    <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">saml-mock</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+    <saml:EncryptedAssertion><xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element">
+    <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes192-cbc"/>
+    <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+        <xenc:EncryptedKey>
+            <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+            <xenc:CipherData>
+                <xenc:CipherValue>WWpLAN3UHHTd9tQFPyZUCtU1ovoKZw+oZS1habK9p80+BMw9mWyt/3kGvOVwt0At
+hlugLyauC6+pBlC74PbrKMPyakBa6IrfWB9b5i/NTpSiDHwUp4vI/5xT+7QP6D7f
+UYC5bI8x5tYPqz3l3EwOwLV4kFrsece4ZVIeaR4Rwtk=</xenc:CipherValue>
+            </xenc:CipherData>
+        </xenc:EncryptedKey>
+    </dsig:KeyInfo>
+    <xenc:CipherData>
+        <xenc:CipherValue>zrmAKDiC0McpUHTzVF4/EThdIRGEd7rNdkl9llAqYcaBnd8bWLsLkbBy9ZRIYhuJ
+QO50H2siH/ODcvJ2NdznkpReinjV9BuauWp3m6poRcO3IoUF9fF71HZbmnu0286r
+HT0tKf2UkFMUUx3b28otC9BceeAlgdv9lzZX8RNs0AVxwMl0ylrMjjB2BbUGRDiT
+6BkAG7vyNA3cQuqjOvlFqTRLfAI8KjjPwF8DwbrPVJC4seMBlIGts6gOkV3AUTWr
+QTn317sh/+kcIXJovTmxxiJWnMR+5/KOp/MGOsEw+87zE9egmVBOW47c2j+VHQWu
+DTzg/T8jXWI/n0PHisJyupYIdtOcFX3JrVi5ezrUNVquin9oiSXMmEe3KOgeTzSk
+P2V7MH+NWjw/vta5HHRYu3ZyYepdSwRckMIQk73VUTql5r8vucWUZjoeRIqfWXeq
+Wo6xEPhsJO2rch+k4TUMrPA3EgNVJZO/15NhbgZB3NT3zIIAgTE6jQMrYfAa9voR
++6u9e9BCTmYmWXgMdWxF+U39koOuE2MO9PfUQZ8RvxOACDsHJ8v2H3x5fBf3bMKC
+oE1WLg2DLHB0xkIzmJeJ59MfV2lmwAE9slc6m8AtF5CeWLBx7wX/XE+Kb1Do9XCe
+3V32sI3vB82jqFo2eddTEyaDGUQT73+DmY5RfGAmQBrd9nkgZqzW316mVevFz4eu
+Ox31My36zajAHYfMAeKt3xbI7TbUzGkBKz3x7DreNUpV8WnwZKl/SrigYMRFbsVe
+pNtGVD3R+RmWsV8pCZBlemTZaTCu7aiRuw0QYCy9xWZ6RCitcK6mCvomrIEUWJ2s
+eKF2YUEZfKO69Cg3eqviQ8KBVHYE2Uuy+u/avuJAL4ItSPFnE3zoB6TlfAfcoU+P
+cPvQ0kgFCDoqysvq2UctSOZjLSad387GmNuT2Pd8tob6J4f2j7TixGYBkb8gGa1i
+4o0RHIRBIgCS0A+0d9GtVSlDrMpifARqIOPsn2Z6OIgQuj4CrPRLinWECQ03Wpvf
+5S8MPomTr0rji8YFttGLG6xnkebXG8w0jmeFx5odR99BACQcRIjpwT9Ifa7HY7kh
+DbHvH1JRVZ0KmW9Md/1IScuVZB+saTUEXEGrddb7qtCoqPb2VKlZF2nT8PqivXWm
+yI1jdGOI8QC3xOJgkNaB81S92GbOrNyH/p8h2lYxfiwgJqjf+ioBcdUau06/UQnp
+zUQv1711eyacIy2gHQSzG412EbS0XYm6WyMR13gW1LKrx/6/vhNdTT9LJ2tx4Tzq
+jLNCV+f9yy4fezUxHOxc0Wp4MqSBucQRIsciIPzDhXMnM0u+OCAFVGEUtcWMv7x9
+/OV3IY/cRC/U1hnqIhT45UAmwyWbjLED+Z4enLxOkQqKQyH2TPwxUSa5ElfGQGyR
+uQ012pCOaqlGWTfeLWvcIC7U865EXjRPqK/9Cc2MmjSCUr8rg//IxI59jJY0km2j
+sYmHpuYcZK1XE/hCNKi1Z/JshkImBGKsZZyJXMLkdeiIBz/l+uvX8YvtZuLx0ITb
+LQBUUWwQEVHGsDtye/UigMLkyETWu1C5eaSBQ3NyMsxS7LDRG3k02eNjFyNFNfkM</xenc:CipherValue>
+    </xenc:CipherData>
+</xenc:EncryptedData></saml:EncryptedAssertion></samlp:Response>

--- a/test_vectors/response_encrypted_valid_aes192_gcm.xml
+++ b/test_vectors/response_encrypted_valid_aes192_gcm.xml
@@ -1,0 +1,45 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_valid_aes192_gcm_encrypted_response" InResponseTo="example" Version="2.0" IssueInstant="2025-03-04T21:09:01.566Z" Destination="http://localhost:8080/saml/acs">
+    <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">saml-mock</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+    <saml:EncryptedAssertion><xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:xenc11="http://www.w3.org/2009/xmlenc11#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element">
+    <xenc:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes192-gcm"/>
+    <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+        <xenc:EncryptedKey>
+            <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+            <xenc:CipherData>
+                <xenc:CipherValue>VaPt6XIW6CVZnoo7kr6WDoBTuZXg9NRFLDrvvJnp4Q+i6D5gFg95kT44vRbZ3DZa
+6pAPEuVphtwqZ/YX0X8vGo8HqdcV9nVd/6j4et8s0WaKbgIrwlJnEKzbFJ3hshS+
+8Fy3MsxivdmefvdSkH32e+QY7NGmLn8BiIko5k2M3Ww=</xenc:CipherValue>
+            </xenc:CipherData>
+        </xenc:EncryptedKey>
+    </dsig:KeyInfo>
+    <xenc:CipherData>
+        <xenc:CipherValue>/IPBiwYgqjaoRk0RCGeTMczX8EL/AQ4du20icoqdgZ6JfxSR0by6GFpXxxMeSkaM
+/8uvI6l2hYRcTRhqwS+oqt/xZVh7IACfDGB4EQ4I18q8yiYY4rVkbNM3nLObXDLX
+dOrkGKi8YNm8SjA/aflddejBVHKWRBlicyg46/DC3R9Ci2kMflXsr0FsY02Ms8s+
+ctK3Tv6qrn8orTW2t5B/Ui3+h8ZZdL5tagGKdc4yWrRw7RGmbK5Q8OaI2cNlSB1u
+6p7g2SShOY43AlzOsZpdjvkLjU5E3ssQVb2kOtvaOt0EyTS1qLUSqFu5IszuNyWI
+fjXfbgiCs+EhB4RBQKknKC+fXkJ/LNuIBUqj/Bya60gvhyCoi0xpa3a5ZBLxBwrS
+kNAXSS1gJpqhLI6pUGi8s7cFQsk6/khgORQ7NiGLBMkxSHcwK0oXEvSk+M5XtzUE
+hlTZFozohWuQkY189XMueoH6XRiimql2BCFd+NaYNR9VmGaU8KKvaSBr7m5BR9A0
+rAvstUgJwXIRGwqOvgjk61lpubX5ZOPUp7jDrTDscQ4MI0AyaorZPbE/qAFzwND6
+YPZe/eqRebsdFFi+7CLNMCCoJ8qI4VagJY4CmufOFercqhKcQ91PYbL8pJdiK5h4
+21SPFnG7GH9TRtM+cgV5d2LA4VR6l7BirpnfU4TMubS1R1PG0jexdxwXeGE2JqPe
+lJwEROxBysHkiTZtUKPgMaA5SuCLAf/2mdCWqpc57BE6TbvWelWvEngmZh8PEFeH
+3fkkmMVwnRCo98jwnk4+HAFvvb3BJNIjTHoVvnwqcnwn3eVE8jlAhdympWYzgUqV
+RLJLxRJd+uDeRKcnsekdhWDI3T4IKdE+XMR9ifFSeLKw+XF/Vw5zG4swaB3B3KLL
+T5mvPKx2S8MtNgiMH1SUqILLlUljncPjI2YoqHdg33z3QcyS+prluahqtf8YRwpn
+0GtFjWjXP7ivE3jrD3JbopUc9/5/yKPtlVe2chjKJqMaSN9BRIxRReo9iEb+ks1q
+wwG0mQiz2iRttESSNKCcHqhqlc1nfrdS2gZGpYkqKGUz+jyjoajvEJ9prGUMLbeV
+JmRZpwJYzr5yROxuG62gcdC0zGtoUpY3itYdQN8Msw4jLVjq9HS9KoqyR3BRWqCz
+pqEWXHG5SKH8e8ayjdB9WDmiYR/2Tcs1JbnW4SxZwrLwdIFrbUHBFesqED6QPwLY
+ZTZujfhPMmHnaHdAK0nCqflSIv5DnDlEFBmyBuTnQxC3dVeG7aDeCY0kwmYw742m
+/N6gKwZmmAWgGe6xIqMn2TLyAaqnF/gRPFAFQFhNQE4u1EMur/HU0UPi/xQOg6+j
+u19PaLCUUo+QF1u9wvIcC7JzvutEUv7vtsjO0D+9F7b16RT3rccyBF0ZAxrFF7VV
+2W3agIMR5ESHQXfEnt08Lft4UZRiBQtxRaSbDhd+WPup1aRJzq7zukMfco/gm5YY
+03hvjhTJpRZcZAyVDwxYYTAKYGb22Q3nw9gk8WiNtsQTe90ZyxDKYZwMLZqM8yQP
++K1ZXREiAO+FqYZw7srgcjc6EXqQ5C7zv4shyIRlMLPftiZqrBxcWh5w3vKu4g==</xenc:CipherValue>
+    </xenc:CipherData>
+</xenc:EncryptedData></saml:EncryptedAssertion></samlp:Response>

--- a/test_vectors/response_encrypted_valid_aes256_cbc.xml
+++ b/test_vectors/response_encrypted_valid_aes256_cbc.xml
@@ -1,0 +1,45 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_valid_aes256_cbc_encrypted_response" InResponseTo="example" Version="2.0" IssueInstant="2025-03-04T21:09:01.566Z" Destination="http://localhost:8080/saml/acs">
+    <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">saml-mock</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+    <saml:EncryptedAssertion><xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element">
+    <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+    <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+        <xenc:EncryptedKey>
+            <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+            <xenc:CipherData>
+                <xenc:CipherValue>VQBQQnQHXQIj4e973qbjAWz0OgQpDlDoSe5oI+PO6Yuk+HshU0wjc6iENANxJkOy
+P72V0ImlnczCiph80kVhRfge/vpV8zs0OYW5nwH9lnASqE9vlkwJyvrVd6NSQOJD
+lGFLowlRmRM0hm7vZoZXC8uNX54bX0Ix3XFbSX8ZMKQ=</xenc:CipherValue>
+            </xenc:CipherData>
+        </xenc:EncryptedKey>
+    </dsig:KeyInfo>
+    <xenc:CipherData>
+        <xenc:CipherValue>tYs1i+8foCn7/rF4UF4Y+1BvNU9Rb8HiXYGhO0EWOmNPX91LcFaNbnqXmeBXcx4e
+K0aXelvF/2rn3pmFxZeucplUs5hNlUEUvyQsZOlWDXluAkaLDXLasZhsEojfGqRX
+NYboZGT/psKKzW9JSg+k2oOq9N+qEpzxHDJNGVCiG1VVEIyy0GqPhUDW4g3p4G98
+ccFGOEow3j0jSKQU/EU/FtiJAzUJGl8Be1425lifcHn7YLytfCURcqz1Krolrhzs
+Zwr1lbkr1VqD5D+FiD87rTQQXSQmVpbojQpqG86osy7T3Sr06J+LIFjvOLMR+ddD
+mSRgh+l30oGrWtuzsb/GWb/Xo5ZrRh6p4QvWXQxZB5OYZBoqsQGIhyEX3y45OwdU
+6t+wkMMA/nZRFmmMf3q7tc6RLiATCN6epqlgAnaCijMk6s+nOdKs2R9no0vwr1IX
+rSr8eJZOATa/1p9Q9It2eQ833Bb1hCcg4gc5kHjqK7K2ODUiM45Fbnk/4Khk1wsP
+BnhUGVhwcnkpKjXI5BLJPAWxDnEioZFiG4Aw/PoihD4fFQ5bkWLpZ7gFHfq79wHf
+rD8RzC9q9kAqIOJFPLJv1AThNYSxTzgNFCbZPazx+aa4A8JjhoaBeRGrZD9CcBkb
+x2ESQfkp/M44rxO8AtI62xj8iN0OE3rYMeZ4YKS5wjjLX4onsFbAIEaQCTs+DgQW
+SbyqDH+Q5vxh1LeNpZAj0l0z0pzm8xPPxUYSU4T3Od7bGowMPFsEMQO/rmYM1pyg
+uI8bWuU0iITxbZvnz05AlQL14cMlyGDc6Hqf3oEkMg0cXlyKmjdJxcXEXFqW8wa2
+b3OXWcZATxa4BXpBXrBsn/gcsBsmDhD1LRcf9mYp69DaGXHdLWHT+fXDLv/sMDlB
+RsqCGlvG1Q7i5+mPUrcIW0TNh9uobp14T0AH5SNzzhthySYdevbGoOr6ghvTK0iQ
+WY6IFOYIcHT7uiBhUs+jMjxnbLBIR0VwJUjtalXiNK+FhzTJWi0N6W4y5FERoXr3
+iLFgADnqWt0RFN2EGZXWShqd8PP67JJ/Fol1kAzsw9d/eIZoYxpzvUmYd8fvHTfm
+gz+i3q1Ozhyn+H8jBFmusvMflhtIGCsQv5N6LDTGsQHXmi8V9jfzxucQxWq80dd4
+PuQJDVX5LgjlXAQnPeTAteQM2M6Jo1E2K+WgiQ6FbabTqccnuGJQ0w0krzrkGgJU
+4B26JsCSCieUFZINrPHV61Ty6zVnip3tfASMsstn2ZhLwpOzVgh4WlPyS5TIJi03
+VnbRks5iSyQ9m2zKEeSB00HK8tg1cdUR0opFZchQd/MXaQmeYAtEHBbkVbMHIDnf
+gmyaWf0rz0gWiVXfJqRQDFZx+T1XllWl2ojq6fDV3UbpEAS/hVJ51hKPaR7czYXJ
+Lo4AUsE01rF7+GLCJwBYU9zxgB8n3K5tJIiF/gWv3yyxpU3eLdlLg/xjGomWh3qb
+V/7+RdN3hZiyR3UeKFewyr+JcdlaaES6ZAKIf9UN3IoTtLqwXi9Mstgf6+gzmMge
+OIDIjXw4dBTsjBGnt+zb1qrN8GHA/i9ZNKtiwbCeZ00Pv0OKwmcchMaQb3tbvQfV</xenc:CipherValue>
+    </xenc:CipherData>
+</xenc:EncryptedData></saml:EncryptedAssertion></samlp:Response>

--- a/test_vectors/response_encrypted_valid_aes256_gcm.xml
+++ b/test_vectors/response_encrypted_valid_aes256_gcm.xml
@@ -1,0 +1,45 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_valid_aes256_gcm_encrypted_response" InResponseTo="example" Version="2.0" IssueInstant="2025-03-04T21:09:01.566Z" Destination="http://localhost:8080/saml/acs">
+    <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">saml-mock</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+    <saml:EncryptedAssertion><xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:xenc11="http://www.w3.org/2009/xmlenc11#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element">
+    <xenc:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes256-gcm"/>
+    <dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+        <xenc:EncryptedKey>
+            <xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+            <xenc:CipherData>
+                <xenc:CipherValue>PI4l8kHOE/dTN61QSGnR8QEvCrBtiOfseKBeO/lAtt1Ggm2yWyP5zmNRlQVIbStF
+Osl5Pn82M+HImRDrrwiZWjXYVpPpeS54gXe75d31DCqiBK7b+WR14Btu3qsJLoem
+Eq4B7tGASJSynBlqtu0C0YKA8qBqQt0StjaaZw/WjSA=</xenc:CipherValue>
+            </xenc:CipherData>
+        </xenc:EncryptedKey>
+    </dsig:KeyInfo>
+    <xenc:CipherData>
+        <xenc:CipherValue>+SQLxT2mcCvgY7sHKztZNOSK6dKLKfpIw4D8AA4Ah6oRuQpFVzyzL9bk1j2Rdj/C
+N1j39FFCJVT5bLqoI7KTtdCkCuQFN6nzCEdSjlOkMZrZaSwO81mTRqM/TX7DnHGS
+SJAkNSV+tpju8PGlR61HnUa6hNv75QdzAJG6RC+009stSVxfXGUY7no6oSd5IOXV
+XYFadoWusNUofOOhNyJkqxcEisW67Abu9Td0CNgGOWNqqQ/X5t68CqcSaYhxMbM7
+XTPtVYYADgAcyl7uqSQcvL0qpxk0LqXOYoJAEfIj10Ked4u0UFpzxrcNJuVvjcKr
+nuUYW0QrWwOC1NSpJHjEloL1TykTrwfV3NwvjPxPXKHci6QQR4Vgu6CHm/A5gQhr
+ALh1sEZ+QOBR1AUaH1gt7LIE1g7AyxPLJ4+IHeOlTX9JnbcPligZEl/XCdu8ki7r
+a0hk71VHaM0YCznvfpl/dTWyv0jkHZWqPfvXc6QnxeFCJo9Gs+NYyBQl5H+HpQUF
+M+QyIwMbI+8lD5xIA+5DIMLWJsemvD4ZME5C/Oh/6LrF/XhmcihGCIgLcvMNytlN
+KF1VMixJeiCV8bNtDzjwWjBElzFL3adsIQCCin0rrWZ/J6HVvdDoRkF5rqJ2L4K/
+GJzR4X52MsmuzRipGhPYSazw0hm5LmpT9MJv9v6Jbr/OZ/ThrTM+xV98Xv393kom
+C9BUlEI8faAMgWQ2d28Bn6h89BcnSbAE5QlmyDb5HesEJ8BQSYneEWjZIaG/gdeL
+YhB9d8kBW5h74jmlA8gmr5ZoicUlI0EUu+ThvTfB/CoL59EX2MA1QxidhibtWVUC
+uCwO41Gog/X3ZEuHQ0XVcGX45wyQ0clRn3gtdcGf/4EeZOEiKiBhjhQINOj8jIdW
+PHmriBDaNMaTgmco+2nEiRbQjwe1zVILis4PEuQaiQ81rmqtKhCCu2Sb2ZhfI64a
+E9quyNdcgyJdeaMckMd81iaX+z1HMvWu3uyBRsUGRXeX7nTAtJA5MmzI9BPktFpA
+E69w4nbh3333atfDVMQnVWEEhxIoHvDJrX455ypDQR9ORmohbIoJIRtmzk4oasvB
+PlA6K+88uQ70Vdib3RRnuFNycEAFFEactT6Oy6kMgw9JEK4jmLCTSwZ2XXdJQRGp
+BegONz3xZmarV4gCuCb0Hnud6C/ZOS1kxM9NNX67SHa7POrhY+bzhHS+l9t2tJeh
+WMfryOrwvb+GT5Eb2jDXZU15ETp3sKEjPOcQ5BkwHPCkB3pZPx61lEYwPBUk0965
+T43ii4haCBr+d14BDleI2WdtMXWQ3iTZCIX85HmAc6XK5U21zqV6dN195XC8sEbn
+9xWkHNcjAmoADupLwQVd9pmlVmrt0Jj23HVhUiFhP+YtyKvIubqf56suo6U8HB0y
+v7Z1FZkOSg514NdPYxxDtTflXec9pOSpemsqUiiU7FZitIf781COqnMZ7Vv0zWTZ
++lSYNwmyS1vFFY3XSI7FakFGS96f3QSGGxJhtjN9tjqSsjeGSq9IBsQTCJjIt8OE
+TC3Rup2K728tJpy59odBIaUACgRraaPxPSSmE4mS54WlvPMZc/U3o8a6rS0QWw==</xenc:CipherValue>
+    </xenc:CipherData>
+</xenc:EncryptedData></saml:EncryptedAssertion></samlp:Response>


### PR DESCRIPTION
## What

Adds match arms in `decrypt_assertion_value_info` (`src/crypto/xmlsec/mod.rs`) for:

- `http://www.w3.org/2001/04/xmlenc#aes192-cbc`
- `http://www.w3.org/2001/04/xmlenc#aes256-cbc`
- `http://www.w3.org/2009/xmlenc11#aes192-gcm`
- `http://www.w3.org/2009/xmlenc11#aes256-gcm`

Each new arm mirrors the existing AES-128-CBC / AES-128-GCM arm, swapping the OpenSSL `Cipher` constructor.

## Why

`ServiceProvider::metadata()` already advertises CBC-128/192/256 in the SP's `<KeyDescriptor>` `EncryptionMethod` block, but the decryption path only implemented AES-128-CBC and AES-128-GCM. Identity providers that pick the strongest advertised algorithm (e.g. AES-256-CBC) hit `EncryptedAssertionValueMethodUnsupported` even though the SP claimed support. This PR aligns the implementation with what the metadata advertises.

## Test coverage

8 new tests in `src/service_provider/tests.rs`, mirroring the existing `test_decrypt_assertion` / `test_decrypt_and_validate_assertion` pattern (one decrypt-only and one full-validation test per new algorithm).

8 new fixtures in `test_vectors/`, generated with `xmlsec1 --encrypt` against the existing `sp_cert.pem` / `sp_private.pem` keypair (rsa-oaep-mgf1p key transport). Generation procedure documented in `test_vectors/README.md`, parallel to the existing signed-response generation docs.

`README.md` supported-algorithm list updated to reflect the four new arms.

## Commits

Split into two for review:

1. ` feat: support AES-192-CBC and AES-256-CBC assertion decryption ` — the metadata-implementation alignment that motivated the PR
2. ` feat: support AES-192-GCM and AES-256-GCM assertion decryption ` — included for completeness alongside the existing AES-128-GCM arm

Either commit could land independently; they're separable.

## Notes

- No new dependencies — `Cipher::aes_192_cbc()`, `Cipher::aes_256_cbc()`, `Cipher::aes_192_gcm()`, `Cipher::aes_256_gcm()` already exist in the `openssl` crate the project uses.
- The fixture-generation procedure had one gotcha worth flagging: `xmlsec1` (correctly) strips redundant `xmlns:dsig` declarations on `<dsig:KeyInfo>` since the prefix is already in scope from the parent `<xenc:EncryptedData>`. samael's serde-based parser requires the explicit `xmlns:dsig` attribute on the `<dsig:KeyInfo>` element itself (`EncryptedKeyInfo.ds` in `src/key_info.rs`), so the post-processing step in `test_vectors/README.md` re-adds it.
- All new tests pass on Apple Silicon (Darwin 25.4.0) against `xmlsec1 1.3.10` with the openssl backend.