### PR TITLE
add feature to allow only certain algorithms

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,0 @@
-source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
-
-nix_direnv_manual_reload
-
-use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,25 @@
 /target
+.tmp
 /.direnv
+/.devenv*
 /result
 **/.DS_Store
 .idea
+
+# Devenv
+devenv.local.nix
+devenv.local.yaml
+
+# pre-commit
+.pre-commit-config.yaml
+
+# Devenv
+.devenv*
+devenv.local.nix
+devenv.local.yaml
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/README.md
+++ b/README.md
@@ -43,35 +43,27 @@ If you want to use the `"xmlsec"` feature, you'll need to install the following 
 
 # Build instructions
 
-We use [nix](https://nixos.org) to faciliate reproducible builds of `samael`.
-It will ensure you have the required libraries installed in a way that won't cause any issues with the rest of your system.
-If you want to take advantage of this, you'll need to put in a little bit of work.
+We use [nix](https://nixos.org) flakes to provide the Rust toolchain and the C libraries required by the `xmlsec` feature without installing them globally. `flake.lock` is the single project lock file for both builds and the development shell.
 
 1. [Install nix](https://github.com/DeterminateSystems/nix-installer)
-1. Install [direnv](https://direnv.net/) and [cachix](https://docs.cachix.org)
+1. Build the library:
+   ```sh
+   nix build --accept-flake-config
    ```
-   # Add ~/.nix-profile/bin to your path first
-   nix profile install nixpkgs#direnv
-   nix profile install nixpkgs#cachix
+1. Enter the development shell:
+   ```sh
+   nix develop --no-pure-eval --accept-flake-config
    ```
-1. Run `cachix use nix-community` to enable a binary cache for the rust toolchain (otherwise you'll build the rust toolchain from scratch)
-1. `cd` into this repo and run `direnv allow` and `nix-direnv-reload`
-1. Install the [direnv VS Code extension](https://marketplace.visualstudio.com/items?itemName=mkhl.direnv)
 
-## Building the library
-
-Just run `nix build`
-
-## Entering a dev environment
-
-If you followed the above instructions, just `cd`-ing into the directory will setup a reproducible dev environment,
-but if you don't want to install `direnv`, then just run `nix develop`.
-
-From their you can build as normal:
+Useful commands inside the development shell:
 
 ```sh
-cargo build --features xmlsec
-cargo test --features xmlsec
+samael-build
+samael-test
+samael-clippy
+samael-fmt
+samael-doc
+samael-audit
 ```
 
 # How do I use this library?

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,86 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1781627264,
+        "narHash": "sha256-TPj5d5MUyvuQZjsfDAAoYJ0SB+tNNNBrdCpD8XL0WeU=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "0fe5629a2955141c336b95e384e2c793c01214fb",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1781620901,
+        "narHash": "sha256-UF6scQlG+6lRkZBUpn/3KNavhOo5G8kDWhjVHcno8uc=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "2df109b343d3c68efd752e32a444a1d9b9f89afa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781454065,
+        "narHash": "sha256-d2xfDjnfRuf/xYGdu9VVRHiav/2w5hDL/5cw2TuVAXw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9eac87a12312b8f60dd52e1c6e1a265f6fc7f5fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781666412,
+        "narHash": "sha256-Tzgol+o9+V4lK99r4AERI4pyFoZwg6Si2xUd1wc/WQU=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d0e019d9543f0f1215a3d961fc4dca59aa29c638",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,67 @@
+{ pkgs, lib, ... }:
+
+let
+  inherit (pkgs) stdenv;
+  samaelEnv = import ./nix/samael-env.nix { inherit pkgs lib; };
+  check = name: "nix build --accept-flake-config .#checks.${stdenv.system}.${name} -L";
+in
+{
+  languages.rust = {
+    enable = true;
+    channel = "nightly";
+    lsp.enable = false;
+    components = [
+      "rustc"
+      "cargo"
+      "clippy"
+      "rustfmt"
+      "rust-src"
+    ];
+  };
+  languages.c.enable = false;
+
+  packages = samaelEnv.nativeBuildInputs ++ (with pkgs; [
+    cargo-audit
+    cargo-nextest
+    nix
+    nixpkgs-fmt
+  ]);
+
+  env = samaelEnv.env;
+
+  scripts = {
+    "samael-build" = {
+      description = "Build the default Nix package.";
+      exec = "nix build --accept-flake-config -L";
+    };
+
+    "samael-test" = {
+      description = "Run the xmlsec nextest check.";
+      exec = check "samael-nextest";
+    };
+
+    "samael-clippy" = {
+      description = "Run the clippy check.";
+      exec = check "samael-clippy";
+    };
+
+    "samael-doc" = {
+      description = "Build crate documentation.";
+      exec = check "samael-doc";
+    };
+
+    "samael-fmt" = {
+      description = "Check formatting.";
+      exec = check "samael-fmt";
+    };
+
+    "samael-audit" = {
+      description = "Audit dependencies.";
+      exec = check "samael-audit";
+    };
+  };
+
+  enterTest = ''
+    samael-test
+  '';
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,8 @@
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+  rust-overlay:
+    url: github:oxalica/rust-overlay
+    inputs:
+      nixpkgs:
+        follows: nixpkgs

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,39 @@
         "type": "github"
       }
     },
+    "cachix": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "git-hooks": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777487137,
+        "narHash": "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "a66a440c321d35f7193472c317f42a55ccd1cb93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "latest",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
     "crane": {
       "locked": {
         "lastModified": 1773189535,
@@ -28,6 +61,91 @@
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crate2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772186516,
+        "narHash": "sha256-8s28pzmQ6TOIUzznwFibtW1CMieMUl1rYJIxoQYor58=",
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "inputs": {
+        "cachix": "cachix",
+        "crate2nix": "crate2nix",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "ghostty": "ghostty",
+        "git-hooks": "git-hooks",
+        "nix": "nix",
+        "nixd": "nixd",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780630679,
+        "narHash": "sha256-hhQyVAYmNKziZ0T+T4Gsk0PYmnz4vdzOzpkJAmDASKM=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "90ed6227ab389dd4e874a69a724f25dba312b754",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -49,6 +167,110 @@
         "type": "github"
       }
     },
+    "ghostty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779069789,
+        "narHash": "sha256-ojo+gso45/6CVSuqfSVnlWpQ4d0QeLgwok+v/g3yu0E=",
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "4b7bf0b20e3baf9c1ba10c63f2ad1fd853faea8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "git-hooks-nix": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-23-11": [
+          "devenv"
+        ],
+        "nixpkgs-regression": [
+          "devenv"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779748925,
+        "narHash": "sha256-meIhqGC04O5VXbKSFXSQoOKp+XCq5RMnwAk1Guo0VQo=",
+        "owner": "cachix",
+        "repo": "nix",
+        "rev": "0bc443c8ff235c3547d09327b48aaa2ab98b15f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "devenv-2.34",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nix-filter": {
       "locked": {
         "lastModified": 1757882181,
@@ -61,6 +283,32 @@
       "original": {
         "owner": "numtide",
         "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixd": {
+      "inputs": {
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1778381404,
+        "narHash": "sha256-FqhdOTA8vyoIpkHhbs2cCT7h6EWM7nsLeOYJc1ifQLE=",
+        "owner": "nix-community",
+        "repo": "nixd",
+        "rev": "e3e45eb76663f522e196b7f0cf34cab201db7779",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixd",
         "type": "github"
       }
     },
@@ -84,6 +332,7 @@
       "inputs": {
         "advisory-db": "advisory-db",
         "crane": "crane",
+        "devenv": "devenv",
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
@@ -122,6 +371,28 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixd",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -16,9 +16,19 @@
       url = "github:rustsec/advisory-db";
       flake = false;
     };
+    devenv = {
+      url = "github:cachix/devenv";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-overlay.follows = "rust-overlay";
+    };
   };
 
-  outputs = { self, nixpkgs, nix-filter, rust-overlay, crane, advisory-db, flake-utils }:
+  nixConfig = {
+    extra-trusted-public-keys = [ "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=" ];
+    extra-substituters = [ "https://devenv.cachix.org" ];
+  };
+
+  outputs = { self, nixpkgs, nix-filter, rust-overlay, crane, advisory-db, flake-utils, devenv } @ inputs:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
@@ -26,10 +36,7 @@
             (import rust-overlay)
             (final: prev: {
               nix-filter = nix-filter.lib;
-              rust-toolchain = pkgs.rust-bin.nightly.latest.default;
-              rust-dev-toolchain = pkgs.rust-toolchain.override {
-                extensions = [ "rust-src" ];
-              };
+              rust-toolchain = final.rust-bin.nightly.latest.default;
             })
           ];
           pkgs = import nixpkgs {
@@ -38,17 +45,7 @@
           craneLib =
             (crane.mkLib pkgs).overrideToolchain pkgs.rust-toolchain;
           lib = pkgs.lib;
-          stdenv = pkgs.stdenv;
-          commonNativeBuildInputs = with pkgs; [
-            libiconv
-            libtool
-            libxml2
-            libxslt
-            llvmPackages.libclang
-            openssl
-            pkg-config
-            xmlsec
-          ];
+          samaelEnv = import ./nix/samael-env.nix { inherit pkgs lib; };
           fixtureFilter = path: _type:
             builtins.match ".*test_vectors.*" path != null ||
             builtins.match ".*\.h" path != null;
@@ -59,29 +56,12 @@
             filter = sourceAndFixtures;
           };
           cargoFile = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-          commonArgs = {
+          commonArgs = samaelEnv.env // {
             pname = "samael";
             inherit src;
             version = cargoFile.package.version;
 
-            # Need to tell bindgen where to find libclang
-            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-
-            # Set C flags for Rust's bindgen program. Unlike ordinary C
-            # compilation, bindgen does not invoke $CC directly. Instead it
-            # uses LLVM's libclang. To make sure all necessary flags are
-            # included we need to look in a few places.
-            # See https://web.archive.org/web/20220523141208/https://hoverbear.org/blog/rust-bindgen-in-nix/
-            BINDGEN_EXTRA_CLANG_ARGS = "${builtins.readFile "${stdenv.cc}/nix-support/libc-crt1-cflags"} \
-                ${builtins.readFile "${stdenv.cc}/nix-support/libc-cflags"} \
-                ${builtins.readFile "${stdenv.cc}/nix-support/cc-cflags"} \
-                ${builtins.readFile "${stdenv.cc}/nix-support/libcxx-cxxflags"} \
-                -idirafter ${pkgs.libiconv}/include \
-                ${lib.optionalString stdenv.cc.isClang "-idirafter ${stdenv.cc.cc}/lib/clang/${lib.getVersion stdenv.cc.cc}/include"} \
-                ${lib.optionalString stdenv.cc.isGNU "-isystem ${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc} -isystem ${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc}/${stdenv.hostPlatform.config} -idirafter ${stdenv.cc.cc}/lib/gcc/${stdenv.hostPlatform.config}/${lib.getVersion stdenv.cc.cc}/include"} \
-            ";
-
-            nativeBuildInputs = commonNativeBuildInputs;
+            nativeBuildInputs = samaelEnv.nativeBuildInputs;
             cargoExtraArgs = "--features xmlsec";
             cargoTestExtraArgs = "--features xmlsec";
           };
@@ -96,27 +76,9 @@
           # `nix build`
           packages.default = samael;
 
-          # `nix develop`
-          devShells.default = pkgs.mkShell {
-            # Need to tell bindgen where to find libclang
-            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-
-            # Set C flags for Rust's bindgen program. Unlike ordinary C
-            # compilation, bindgen does not invoke $CC directly. Instead it
-            # uses LLVM's libclang. To make sure all necessary flags are
-            # included we need to look in a few places.
-            # See https://web.archive.org/web/20220523141208/https://hoverbear.org/blog/rust-bindgen-in-nix/
-            BINDGEN_EXTRA_CLANG_ARGS = "${builtins.readFile "${stdenv.cc}/nix-support/libc-crt1-cflags"} \
-                ${builtins.readFile "${stdenv.cc}/nix-support/libc-cflags"} \
-                ${builtins.readFile "${stdenv.cc}/nix-support/cc-cflags"} \
-                ${builtins.readFile "${stdenv.cc}/nix-support/libcxx-cxxflags"} \
-                -idirafter ${pkgs.libiconv}/include \
-                ${lib.optionalString stdenv.cc.isClang "-idirafter ${stdenv.cc.cc}/lib/clang/${lib.getVersion stdenv.cc.cc}/include"} \
-                ${lib.optionalString stdenv.cc.isGNU "-isystem ${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc} -isystem ${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc}/${stdenv.hostPlatform.config} -idirafter ${stdenv.cc.cc}/lib/gcc/${stdenv.hostPlatform.config}/${lib.getVersion stdenv.cc.cc}/include"} \
-            ";
-
-            buildInputs = with pkgs; [ rust-dev-toolchain nixpkgs-fmt ];
-            nativeBuildInputs = commonNativeBuildInputs;
+          devShells.default = devenv.lib.mkShell {
+            inherit inputs pkgs;
+            modules = [ ./devenv.nix ];
           };
 
           checks = {

--- a/nix/samael-env.nix
+++ b/nix/samael-env.nix
@@ -1,0 +1,30 @@
+{ pkgs, lib }:
+
+let
+  inherit (pkgs) stdenv;
+in
+{
+  nativeBuildInputs = with pkgs; [
+    libiconv
+    libtool
+    libxml2
+    libxslt
+    llvmPackages.libclang
+    openssl
+    pkg-config
+    xmlsec
+  ];
+
+  env = {
+    LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+    BINDGEN_EXTRA_CLANG_ARGS = ''
+      ${builtins.readFile "${stdenv.cc}/nix-support/libc-crt1-cflags"} \
+      ${builtins.readFile "${stdenv.cc}/nix-support/libc-cflags"} \
+      ${builtins.readFile "${stdenv.cc}/nix-support/cc-cflags"} \
+      ${builtins.readFile "${stdenv.cc}/nix-support/libcxx-cxxflags"} \
+      -idirafter ${pkgs.libiconv}/include \
+      ${lib.optionalString stdenv.cc.isClang "-idirafter ${stdenv.cc.cc}/lib/clang/${lib.getVersion stdenv.cc.cc}/include"} \
+      ${lib.optionalString stdenv.cc.isGNU "-isystem ${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc} -isystem ${stdenv.cc.cc}/include/c++/${lib.getVersion stdenv.cc.cc}/${stdenv.hostPlatform.config} -idirafter ${stdenv.cc.cc}/lib/gcc/${stdenv.hostPlatform.config}/${lib.getVersion stdenv.cc.cc}/include"} \
+    '';
+  };
+}

--- a/src/crypto/crypto_disabled.rs
+++ b/src/crypto/crypto_disabled.rs
@@ -1,6 +1,8 @@
 //! This module provides the behaviour if no crypto is available.
 
-use crate::crypto::{CertificateDer, CryptoError, CryptoProvider, ReduceMode};
+use crate::crypto::{
+    AllowedSignatureAlgorithm, CertificateDer, CryptoError, CryptoProvider, ReduceMode,
+};
 use crate::schema::CipherValue;
 
 pub struct NoCrypto;
@@ -16,10 +18,11 @@ impl CryptoProvider for NoCrypto {
         Ok(())
     }
 
-    fn reduce_xml_to_signed(
+    fn reduce_xml_to_signed_with_allowed_algorithms(
         _xml_str: &str,
         _certs: &[CertificateDer],
         _reduce_mode: ReduceMode,
+        _allowed_algorithms: Option<&[AllowedSignatureAlgorithm]>,
     ) -> Result<String, CryptoError> {
         Err(CryptoError::CryptoDisabled)
     }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -61,6 +61,60 @@ impl From<Vec<u8>> for CertificateDer {
     }
 }
 
+/// Allowed XML signature algorithms for signature verification.
+/// By default, all algorithms are allowed. Use this to restrict
+/// signatures and reference digests to approved hash families.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AllowedSignatureAlgorithm {
+    /// RSA-SHA256 (required by most SAML profiles)
+    RsaSha256,
+    /// ECDSA-SHA256 (required by most SAML profiles)
+    EcdsaSha256,
+    /// RSA-SHA224
+    RsaSha224,
+    /// RSA-SHA384
+    RsaSha384,
+    /// RSA-SHA512
+    RsaSha512,
+    /// ECDSA-SHA224
+    EcdsaSha224,
+    /// ECDSA-SHA384
+    EcdsaSha384,
+    /// ECDSA-SHA512
+    EcdsaSha512,
+    /// DSA-SHA256
+    DsaSha256,
+}
+
+impl AllowedSignatureAlgorithm {
+    /// Returns the SignatureMethod URI as defined in XML Signature specifications.
+    pub fn signature_uri(&self) -> &'static str {
+        match self {
+            Self::RsaSha256 => "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+            Self::EcdsaSha256 => "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256",
+            Self::RsaSha224 => "http://www.w3.org/2001/04/xmldsig-more#rsa-sha224",
+            Self::RsaSha384 => "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384",
+            Self::RsaSha512 => "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512",
+            Self::EcdsaSha224 => "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha224",
+            Self::EcdsaSha384 => "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384",
+            Self::EcdsaSha512 => "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512",
+            Self::DsaSha256 => "http://www.w3.org/2009/xmldsig11#dsa-sha256",
+        }
+    }
+
+    /// Returns the DigestMethod URI required for signed references.
+    pub fn digest_uri(&self) -> &'static str {
+        match self {
+            Self::RsaSha224 | Self::EcdsaSha224 => "http://www.w3.org/2001/04/xmldsig-more#sha224",
+            Self::RsaSha256 | Self::EcdsaSha256 | Self::DsaSha256 => {
+                "http://www.w3.org/2001/04/xmlenc#sha256"
+            }
+            Self::RsaSha384 | Self::EcdsaSha384 => "http://www.w3.org/2001/04/xmldsig-more#sha384",
+            Self::RsaSha512 | Self::EcdsaSha512 => "http://www.w3.org/2001/04/xmlenc#sha512",
+        }
+    }
+}
+
 /// Defines which algorithm is used to reduce signed XML.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReduceMode {
@@ -101,13 +155,32 @@ pub trait CryptoProvider {
     /// Takes an XML document, parses it, verifies all XML digital signatures against the given
     /// certificates, and returns output according to `reduce_mode`.
     ///
-    /// `ReduceMode::PreDigest` returns xmlsec's verified pre-digest payload for exactly one
-    /// reference. The validate modes return a rooted XML document derived from the original input
-    /// with all unsigned content removed.
+    /// `ReduceMode::PreDigest` returns xmlsec's verified pre-digest payload for a single verified
+    /// reference, or for the only verified SAML `Response` when several references are signed.
+    /// The validate modes return a rooted XML document derived from the original input with all
+    /// unsigned content removed.
     fn reduce_xml_to_signed(
         xml_str: &str,
         certs_der: &[CertificateDer],
         reduce_mode: ReduceMode,
+    ) -> Result<String, CryptoError> {
+        Self::reduce_xml_to_signed_with_allowed_algorithms(xml_str, certs_der, reduce_mode, None)
+    }
+
+    /// Takes an XML document, parses it, verifies all XML digital signatures against the given
+    /// certificates, and returns output according to `reduce_mode`.
+    ///
+    /// If `allowed_algorithms` is `Some`, only the specified SignatureMethod algorithms
+    /// and their corresponding DigestMethod algorithms will be accepted.
+    /// If `None`, all algorithms are allowed.
+    ///
+    /// This provides protection against algorithm substitution attacks by enforcing signature
+    /// algorithm restrictions at the xmlsec library level before any cryptographic operations.
+    fn reduce_xml_to_signed_with_allowed_algorithms(
+        xml_str: &str,
+        certs_der: &[CertificateDer],
+        reduce_mode: ReduceMode,
+        allowed_algorithms: Option<&[AllowedSignatureAlgorithm]>,
     ) -> Result<String, CryptoError>;
 
     fn decrypt_assertion_key_info(

--- a/src/crypto/url_verification.rs
+++ b/src/crypto/url_verification.rs
@@ -244,7 +244,7 @@ pub fn sign_url(
     Ok(unsigned_url)
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "xmlsec"))]
 mod test {
     use super::UrlVerifier;
     use crate::service_provider::ServiceProvider;

--- a/src/crypto/xmlsec/mod.rs
+++ b/src/crypto/xmlsec/mod.rs
@@ -49,6 +49,12 @@ pub enum XmlSecProviderError {
         error: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    #[error("failed to preserve namespace declaration: {}", error)]
+    XmlNamespaceDeclarationError {
+        #[source]
+        error: Box<dyn std::error::Error + Send + Sync>,
+    },
+
     #[error("encountered malformed XML ID attribute value: {id}")]
     XmlInvalidIdAttribute { id: String },
 
@@ -115,10 +121,90 @@ struct AttributeName {
     namespace: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct NamespaceDeclaration {
+    prefix: String,
+    href: String,
+}
+
 struct ParsedSelection {
     _document: libxml::tree::Document,
     shell_source: Option<libxml::tree::Node>,
     sequence_nodes: Vec<libxml::tree::Node>,
+}
+
+fn signature_uses_allowed_algorithm(
+    sig_node: &libxml::tree::Node,
+    allowed: &[super::AllowedSignatureAlgorithm],
+) -> bool {
+    let Some(signed_info) = signed_info_node(sig_node) else {
+        return false;
+    };
+    let Some(signature_algorithm) = signature_method_algorithm(&signed_info) else {
+        return false;
+    };
+    if !allowed
+        .iter()
+        .any(|allowed_algorithm| allowed_algorithm.signature_uri() == signature_algorithm)
+    {
+        return false;
+    }
+
+    let allowed_digest_algorithms = allowed
+        .iter()
+        .map(super::AllowedSignatureAlgorithm::digest_uri)
+        .collect::<HashSet<_>>();
+    let Some(digest_algorithms) = reference_digest_algorithms(&signed_info) else {
+        return false;
+    };
+
+    digest_algorithms
+        .iter()
+        .all(|algorithm| allowed_digest_algorithms.contains(algorithm.as_str()))
+}
+
+fn signed_info_node(sig_node: &libxml::tree::Node) -> Option<libxml::tree::Node> {
+    sig_node
+        .get_child_elements()
+        .into_iter()
+        .find(|child| is_xml_dsig_element(child, "SignedInfo"))
+}
+
+fn signature_method_algorithm(signed_info: &libxml::tree::Node) -> Option<String> {
+    signed_info
+        .get_child_elements()
+        .into_iter()
+        .find(|child| is_xml_dsig_element(child, "SignatureMethod"))?
+        .get_attribute("Algorithm")
+}
+
+fn reference_digest_algorithms(signed_info: &libxml::tree::Node) -> Option<Vec<String>> {
+    let references = signed_info
+        .get_child_elements()
+        .into_iter()
+        .filter(|child| is_xml_dsig_element(child, "Reference"))
+        .collect::<Vec<_>>();
+    if references.is_empty() {
+        return None;
+    }
+
+    references.iter().map(reference_digest_algorithm).collect()
+}
+
+fn reference_digest_algorithm(reference: &libxml::tree::Node) -> Option<String> {
+    reference
+        .get_child_elements()
+        .into_iter()
+        .find(|child| is_xml_dsig_element(child, "DigestMethod"))?
+        .get_attribute("Algorithm")
+}
+
+fn is_xml_dsig_element(node: &libxml::tree::Node, expected_name: &str) -> bool {
+    node.get_name() == expected_name
+        && node
+            .get_namespace()
+            .map(|namespace| namespace.get_href() == XMLNS_XML_DSIG)
+            .unwrap_or(false)
 }
 
 pub struct XmlSec;
@@ -149,10 +235,14 @@ impl super::CryptoProvider for XmlSec {
     /// Takes an XML document, parses it, verifies all XML digital signatures against the given
     /// certificates, and returns a derived version of the document where all elements that are not
     /// covered by a digital signature have been removed.
-    fn reduce_xml_to_signed(
+    ///
+    /// If `allowed_algorithms` is provided, only those signature algorithms will be accepted.
+    /// This provides protection against algorithm substitution attacks.
+    fn reduce_xml_to_signed_with_allowed_algorithms(
         xml_str: &str,
         certs_der: &[CertificateDer],
         reduce_mode: ReduceMode,
+        allowed_algorithms: Option<&[super::AllowedSignatureAlgorithm]>,
     ) -> Result<String, CryptoError> {
         let mut xml = XmlParser::default().parse_string(xml_str)?;
 
@@ -173,6 +263,12 @@ impl super::CryptoProvider for XmlSec {
         let mut selections = Vec::new();
 
         for sig_node in &signature_nodes {
+            if let Some(allowed) = allowed_algorithms {
+                if !signature_uses_allowed_algorithm(sig_node, allowed) {
+                    return Err(CryptoError::InvalidSignature);
+                }
+            }
+
             let mut verified = false;
             let mut verified_references = Vec::new();
 
@@ -180,6 +276,7 @@ impl super::CryptoProvider for XmlSec {
                 let mut sig_ctx = XmlSecSignatureContext::new_with_flags(
                     wrapper::XMLSEC_DSIG_FLAGS_STORE_SIGNEDINFO_REFERENCES,
                 )?;
+
                 let key = XmlSecKey::from_memory(key_data.der_data(), XmlSecKeyFormat::CertDer)?;
                 sig_ctx.insert_key(key);
                 verified = sig_ctx.verify_node(sig_node)?;
@@ -208,20 +305,7 @@ impl super::CryptoProvider for XmlSec {
         }
 
         if reduce_mode == ReduceMode::PreDigest {
-            if predigest_results.len() == 1 {
-                return Ok(predigest_results.remove(0));
-            } else {
-                for predigest in predigest_results {
-                    return match crate::service_provider::root_element_local_name(&predigest)
-                        .as_deref()
-                    {
-                        // We want to trust the full response as that includes the relevant data.
-                        // Everything is signed so even if we found a signed Assertion in here we could trust it, for now lets keep it minimal.
-                        Some("Response") => Ok(predigest),
-                        _ => Err(CryptoError::InvalidSignature),
-                    };
-                }
-            }
+            return predigest_result(predigest_results);
         }
 
         if selections.is_empty() {
@@ -330,6 +414,26 @@ impl super::CryptoProvider for XmlSec {
 
         Ok(document.to_string())
     }
+}
+
+fn predigest_result(mut predigest_results: Vec<String>) -> Result<String, CryptoError> {
+    if predigest_results.len() == 1 {
+        return Ok(predigest_results.remove(0));
+    }
+
+    let mut response_predigests = predigest_results
+        .into_iter()
+        .filter(|predigest| predigest_root_is_response(predigest))
+        .collect::<Vec<_>>();
+    if response_predigests.len() == 1 {
+        Ok(response_predigests.remove(0))
+    } else {
+        Err(CryptoError::InvalidSignature)
+    }
+}
+
+fn predigest_root_is_response(predigest: &str) -> bool {
+    crate::service_provider::root_element_is_saml_protocol_response(predigest)
 }
 
 /// Searches the document for all attributes named `ID` and stores them and their values in the XML
@@ -843,9 +947,51 @@ fn move_output_root_to_document_root(
 
     let mut new_root = find_node_by_ptr_in_tree(&current_root, output_root_ptr as *const _)
         .ok_or(XmlSecProviderError::XmlPredigestFragmentInvalid)?;
+    let namespaces = in_scope_namespace_declarations(doc, &new_root);
     new_root.unlink();
+    preserve_namespace_declarations(&mut new_root, namespaces)?;
     doc.set_root_element(&new_root);
     Ok(())
+}
+
+fn in_scope_namespace_declarations(
+    doc: &libxml::tree::Document,
+    node: &libxml::tree::Node,
+) -> Vec<NamespaceDeclaration> {
+    node.get_namespaces(doc)
+        .into_iter()
+        .map(|namespace| NamespaceDeclaration {
+            prefix: namespace.get_prefix(),
+            href: namespace.get_href(),
+        })
+        .filter(namespace_declaration_should_be_preserved)
+        .collect()
+}
+
+fn preserve_namespace_declarations(
+    node: &mut libxml::tree::Node,
+    namespaces: Vec<NamespaceDeclaration>,
+) -> Result<(), CryptoError> {
+    let mut declared_prefixes = node
+        .get_namespace_declarations()
+        .into_iter()
+        .map(|namespace| namespace.get_prefix())
+        .collect::<HashSet<_>>();
+
+    for namespace in namespaces {
+        if !declared_prefixes.insert(namespace.prefix.clone()) {
+            continue;
+        }
+
+        libxml::tree::Namespace::new(&namespace.prefix, &namespace.href, node)
+            .map_err(|error| XmlSecProviderError::XmlNamespaceDeclarationError { error })?;
+    }
+
+    Ok(())
+}
+
+fn namespace_declaration_should_be_preserved(namespace: &NamespaceDeclaration) -> bool {
+    !namespace.href.is_empty() && namespace.prefix != "xml" && namespace.prefix != "xmlns"
 }
 
 fn element_identity_matches(left: &libxml::tree::Node, right: &libxml::tree::Node) -> bool {
@@ -1275,6 +1421,57 @@ mod tests {
     }
 
     #[test]
+    fn predigest_result_returns_single_result_without_reclassifying_it() {
+        let assertion = r#"<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"/>"#;
+
+        assert_eq!(
+            predigest_result(vec![assertion.to_string()]).unwrap(),
+            assertion
+        );
+    }
+
+    #[test]
+    fn predigest_result_selects_the_only_response_from_multiple_verified_references() {
+        let response = r#"<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"/>"#;
+        let assertion = r#"<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"/>"#;
+
+        assert_eq!(
+            predigest_result(vec![assertion.to_string(), response.to_string()]).unwrap(),
+            response
+        );
+    }
+
+    #[test]
+    fn predigest_result_rejects_multiple_response_predigests() {
+        let first_response =
+            r#"<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="first"/>"#;
+        let second_response =
+            r#"<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="second"/>"#;
+
+        assert!(matches!(
+            predigest_result(vec![
+                first_response.to_string(),
+                second_response.to_string()
+            ]),
+            Err(CryptoError::InvalidSignature)
+        ));
+    }
+
+    #[test]
+    fn predigest_result_rejects_wrong_namespace_response_from_multiple_verified_references() {
+        let wrong_namespace_response = r#"<evil:Response xmlns:evil="urn:example:evil"/>"#;
+        let assertion = r#"<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"/>"#;
+
+        assert!(matches!(
+            predigest_result(vec![
+                assertion.to_string(),
+                wrong_namespace_response.to_string()
+            ]),
+            Err(CryptoError::InvalidSignature)
+        ));
+    }
+
+    #[test]
     fn validate_and_mark_keeps_ancestors_for_signed_assertions() {
         let xml = r#"
 <Envelope>
@@ -1315,9 +1512,9 @@ mod tests {
     fn validate_and_mark_no_ancestors_roots_signed_assertions_at_the_assertion() {
         let xml = r#"
 <Envelope>
-  <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="response">
+  <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="response">
     <Wrapper>
-      <saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="assertion">
+      <saml:Assertion ID="assertion">
         <saml:Issuer>https://idp.example.com</saml:Issuer>
       </saml:Assertion>
     </Wrapper>
@@ -1344,6 +1541,7 @@ mod tests {
         });
 
         assert!(reduced.contains("<saml:Assertion"));
+        assert!(reduced.contains("xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\""));
         assert!(!reduced.contains("<samlp:Response"));
         assert!(!reduced.contains("<Wrapper>"));
     }

--- a/src/crypto/xmlsec/wrapper/mod.rs
+++ b/src/crypto/xmlsec/wrapper/mod.rs
@@ -11,9 +11,6 @@
 
 #[doc(hidden)]
 pub use libxml::tree::document::Document as XmlDocument;
-#[doc(hidden)]
-#[allow(unused)]
-pub use libxml::tree::node::Node as XmlNode;
 
 mod backend;
 mod bindings;

--- a/src/crypto/xmlsec/wrapper/xmldsig.rs
+++ b/src/crypto/xmlsec/wrapper/xmldsig.rs
@@ -93,25 +93,6 @@ impl XmlSecSignatureContext {
         Ok(result)
     }
 
-    /// Retrieves the URI strings from the verified reference contexts.
-    pub fn get_verified_reference_uris(&self) -> XmlSecResult<Vec<String>> {
-        Ok(self
-            .get_verified_references()?
-            .into_iter()
-            .filter_map(|reference| reference.uri)
-            .collect())
-    }
-
-    /// Retrieves the pre-digest data from the first and only verified reference.
-    pub fn get_predigest_data(&self) -> XmlSecResult<String> {
-        let mut references = self.get_verified_references()?;
-        if references.len() != 1 {
-            return Err(XmlSecError::SigningError);
-        }
-
-        Ok(references.remove(0).predigest_xml)
-    }
-
     /// Sets the key to use for signature or verification. In case a key had
     /// already been set, the latter one gets released in the optional return.
     pub fn insert_key(&mut self, key: XmlSecKey) -> Option<XmlSecKey> {
@@ -127,23 +108,6 @@ impl XmlSecSignatureContext {
         }
 
         old
-    }
-
-    /// Releases a currently set key returning `Some(key)` or None otherwise.
-    #[allow(unused)]
-    pub fn release_key(&mut self) -> Option<XmlSecKey> {
-        unsafe {
-            let ctx = self.ctx.as_mut();
-            if ctx.signKey.is_null() {
-                None
-            } else {
-                let key = XmlSecKey::from_ptr(ctx.signKey);
-
-                ctx.signKey = null_mut();
-
-                Some(key)
-            }
-        }
     }
 
     /// Takes a [`XmlDocument`][xmldoc] and attempts to sign it. For this to work it has to have a properly structured

--- a/src/schema/authn_request.rs
+++ b/src/schema/authn_request.rs
@@ -1,4 +1,6 @@
-use crate::crypto::{CertificateDer, Crypto, CryptoProvider};
+use crate::crypto::CertificateDer;
+#[cfg(feature = "xmlsec")]
+use crate::crypto::{Crypto, CryptoProvider};
 use crate::schema::{Conditions, Issuer, NameIdPolicy, RequestedAuthnContext, Subject};
 use crate::signature::Signature;
 use chrono::prelude::*;
@@ -233,7 +235,7 @@ impl TryFrom<&AuthnRequest> for Event<'_> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "xmlsec"))]
 mod test {
     use super::*;
     use crate::crypto::UrlVerifier;

--- a/src/service_provider/mod.rs
+++ b/src/service_provider/mod.rs
@@ -14,13 +14,22 @@ use base64::{engine::general_purpose, Engine as _};
 use chrono::prelude::*;
 use chrono::Duration;
 use flate2::{write::DeflateEncoder, Compression};
-use quick_xml::{de::DeError, events::Event as XmlEvent, Reader};
+#[cfg(feature = "xmlsec")]
+use quick_xml::{
+    de::DeError,
+    events::{BytesStart, Event as XmlEvent},
+    name::ResolveResult,
+    NsReader, Writer,
+};
 use std::fmt::Debug;
-use std::io::Write;
+use std::io::{Cursor, Write};
 use thiserror::Error;
 use url::Url;
 
 const SUBJECT_CONFIRMATION_METHOD_BEARER: &str = "urn:oasis:names:tc:SAML:2.0:cm:bearer";
+const SAML_PROTOCOL_NS: &str = "urn:oasis:names:tc:SAML:2.0:protocol";
+const SAML_ASSERTION_NS: &str = "urn:oasis:names:tc:SAML:2.0:assertion";
+const SAML_STATUS_SUCCESS: &str = "urn:oasis:names:tc:SAML:2.0:status:Success";
 
 #[cfg(test)]
 mod tests;
@@ -174,6 +183,11 @@ pub struct ServiceProvider {
     pub contact_person: Option<ContactPerson>,
     pub max_issue_delay: Duration,
     pub max_clock_skew: Duration,
+    /// Optional list of allowed signature algorithms for signature verification.
+    /// If None, all algorithms are allowed (insecure, not recommended).
+    /// If Some, only the specified algorithms will be accepted, providing protection
+    /// against algorithm substitution attacks.
+    pub allowed_signature_algorithms: Option<Vec<crypto::AllowedSignatureAlgorithm>>,
 }
 
 impl Default for ServiceProvider {
@@ -194,6 +208,7 @@ impl Default for ServiceProvider {
             contact_person: None,
             max_issue_delay: Duration::seconds(90),
             max_clock_skew: Duration::seconds(180),
+            allowed_signature_algorithms: None,
         }
     }
 }
@@ -401,33 +416,51 @@ impl ServiceProvider {
     ) -> Result<Assertion, Error> {
         let (reduced_xml, reduced_from_verified_signature) =
             if let Some(sign_certs) = self.idp_signing_certs()? {
+                let allowed_algorithms = self.allowed_signature_algorithms.as_deref();
+
                 (
-                    Crypto::reduce_xml_to_signed(response_xml, &sign_certs, reduce_mode)
-                        .map_err(|_e| Error::FailedToValidateSignature)?,
+                    Crypto::reduce_xml_to_signed_with_allowed_algorithms(
+                        response_xml,
+                        &sign_certs,
+                        reduce_mode,
+                        allowed_algorithms,
+                    )
+                    .map_err(|_e| Error::FailedToValidateSignature)?,
                     true,
                 )
             } else {
                 (String::from(response_xml), false)
             };
 
-        match root_element_local_name(&reduced_xml).as_deref() {
-            Some("Response") => {
-                let response: Response = reduced_xml
-                    .parse()
-                    .map_err(Error::FailedToParseSamlResponse)?;
-                return self.validate_parsed_response(response, possible_request_ids);
-            }
-            Some("Assertion") if reduced_from_verified_signature => {
+        match saml_root_element(&reduced_xml)
+            .map_err(|error| Error::FailedToParseSamlResponse(DeError::from(error)))?
+        {
+            Some(SamlRootElement::ProtocolResponse) => match reduced_xml.parse::<Response>() {
+                Ok(response) => {
+                    return self.validate_parsed_response(response, possible_request_ids);
+                }
+                Err(_) if reduced_from_verified_signature => {
+                    let assertion_xml = verified_assertion_from_response_shell(&reduced_xml)
+                        .map_err(Error::FailedToParseSamlAssertion)?;
+                    let assertion: Assertion = assertion_xml
+                        .parse()
+                        .map_err(Error::FailedToParseSamlAssertion)?;
+                    self.validate_assertion(&assertion, possible_request_ids)?;
+                    return Ok(assertion);
+                }
+                Err(error) => return Err(Error::FailedToParseSamlResponse(error)),
+            },
+            Some(SamlRootElement::Assertion) if reduced_from_verified_signature => {
                 let assertion: Assertion = reduced_xml
                     .parse()
                     .map_err(Error::FailedToParseSamlAssertion)?;
                 self.validate_assertion(&assertion, possible_request_ids)?;
                 return Ok(assertion);
             }
-            Some(root_name) => {
-                return Err(Error::FailedToParseSamlResponse(DeError::Custom(format!(
-                    "unexpected SAML root element `{root_name}`"
-                ))));
+            Some(_) => {
+                return Err(Error::FailedToParseSamlResponse(DeError::Custom(
+                    "unexpected SAML root element".to_string(),
+                )));
             }
             None => {}
         }
@@ -711,19 +744,515 @@ impl ServiceProvider {
     }
 }
 
-pub(crate) fn root_element_local_name(xml: &str) -> Option<String> {
-    let mut reader = Reader::from_str(xml);
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum SamlRootElement {
+    ProtocolResponse,
+    Assertion,
+    Unsupported,
+}
+
+#[cfg(feature = "xmlsec")]
+pub(crate) fn root_element_is_saml_protocol_response(xml: &str) -> bool {
+    matches!(
+        saml_root_element(xml),
+        Ok(Some(SamlRootElement::ProtocolResponse))
+    )
+}
+
+fn saml_root_element(xml: &str) -> quick_xml::Result<Option<SamlRootElement>> {
+    let mut reader = NsReader::from_str(xml);
 
     loop {
-        match reader.read_event() {
-            Ok(XmlEvent::Start(start)) | Ok(XmlEvent::Empty(start)) => {
-                return Some(String::from_utf8_lossy(start.local_name().as_ref()).into_owned());
+        match reader.read_resolved_event()? {
+            (namespace, XmlEvent::Start(start)) | (namespace, XmlEvent::Empty(start)) => {
+                return Ok(Some(classify_saml_root(
+                    &namespace,
+                    start.local_name().as_ref(),
+                )));
             }
-            Ok(XmlEvent::Eof) => return None,
-            Ok(_) => {}
-            Err(_) => return None,
+            (_, XmlEvent::Eof) => return Ok(None),
+            _ => {}
         }
     }
+}
+
+fn classify_saml_root(namespace: &ResolveResult<'_>, local_name: &[u8]) -> SamlRootElement {
+    if element_is(namespace, local_name, SAML_PROTOCOL_NS, "Response") {
+        SamlRootElement::ProtocolResponse
+    } else if element_is(namespace, local_name, SAML_ASSERTION_NS, "Assertion") {
+        SamlRootElement::Assertion
+    } else {
+        SamlRootElement::Unsupported
+    }
+}
+
+fn verified_assertion_from_response_shell(xml: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let mut reader = NsReader::from_str(xml);
+    let mut writer = Writer::new(Cursor::new(Vec::new()));
+    let mut namespace_stack = Vec::new();
+    let mut root_seen = false;
+    let mut response_closed = false;
+    let mut depth = 0usize;
+    let mut assertion_count = 0usize;
+    let mut capture_depth = 0usize;
+    let mut status_seen = false;
+    let mut status_depth = None;
+    let mut status_code_count = 0usize;
+
+    loop {
+        let (namespace, event) = reader.read_resolved_event()?;
+        match event {
+            XmlEvent::Start(start) => {
+                if !root_seen {
+                    require_response_root(&namespace, start.local_name().as_ref())?;
+                    validate_only_namespace_declarations(&start, "Response")?;
+                    namespace_stack.push(namespace_declarations(&start)?);
+                    root_seen = true;
+                    depth = 1;
+                    continue;
+                }
+
+                reject_content_after_response(response_closed)?;
+
+                if capture_depth > 0 {
+                    reject_nested_assertion(&namespace, start.local_name().as_ref())?;
+                    namespace_stack.push(namespace_declarations(&start)?);
+                    capture_depth += 1;
+                    depth += 1;
+                    writer.write_event(XmlEvent::Start(start.into_owned()))?;
+                    continue;
+                }
+
+                if status_depth.is_some() && depth > status_depth.unwrap() {
+                    require_status_code(&namespace, start.local_name().as_ref())?;
+                    validate_status_code(&start)?;
+                    namespace_stack.push(namespace_declarations(&start)?);
+                    status_code_count += 1;
+                    depth += 1;
+                    continue;
+                }
+
+                if depth == 1
+                    && element_is(
+                        &namespace,
+                        start.local_name().as_ref(),
+                        SAML_ASSERTION_NS,
+                        "Assertion",
+                    )
+                {
+                    assertion_count += 1;
+                    reject_multiple_assertions(assertion_count)?;
+                    namespace_stack.push(namespace_declarations(&start)?);
+                    let standalone_start = standalone_assertion_start(start, &namespace_stack)?;
+                    writer.write_event(XmlEvent::Start(standalone_start))?;
+                    capture_depth = 1;
+                    depth += 1;
+                } else if depth == 1
+                    && element_is(
+                        &namespace,
+                        start.local_name().as_ref(),
+                        SAML_PROTOCOL_NS,
+                        "Status",
+                    )
+                {
+                    if status_seen {
+                        return reduced_response_shell_error(
+                            "reduced signed response shell contains multiple Status elements",
+                        );
+                    }
+                    validate_only_namespace_declarations(&start, "Status")?;
+                    namespace_stack.push(namespace_declarations(&start)?);
+                    status_seen = true;
+                    status_depth = Some(depth);
+                    status_code_count = 0;
+                    depth += 1;
+                } else {
+                    reject_unexpected_element(&namespace, start.local_name().as_ref())?;
+                }
+            }
+            XmlEvent::Empty(empty) => {
+                if !root_seen {
+                    require_response_root(&namespace, empty.local_name().as_ref())?;
+                    validate_only_namespace_declarations(&empty, "Response")?;
+                    root_seen = true;
+                    response_closed = true;
+                    continue;
+                }
+
+                reject_content_after_response(response_closed)?;
+
+                if capture_depth > 0 {
+                    reject_nested_assertion(&namespace, empty.local_name().as_ref())?;
+                    writer.write_event(XmlEvent::Empty(empty.into_owned()))?;
+                    continue;
+                }
+
+                if status_depth.is_some() && depth > status_depth.unwrap() {
+                    require_status_code(&namespace, empty.local_name().as_ref())?;
+                    validate_status_code(&empty)?;
+                    status_code_count += 1;
+                    continue;
+                }
+
+                if depth == 1
+                    && element_is(
+                        &namespace,
+                        empty.local_name().as_ref(),
+                        SAML_ASSERTION_NS,
+                        "Assertion",
+                    )
+                {
+                    assertion_count += 1;
+                    reject_multiple_assertions(assertion_count)?;
+                    namespace_stack.push(namespace_declarations(&empty)?);
+                    let standalone_empty = standalone_assertion_start(empty, &namespace_stack)?;
+                    namespace_stack.pop();
+                    writer.write_event(XmlEvent::Empty(standalone_empty))?;
+                } else if depth == 1
+                    && element_is(
+                        &namespace,
+                        empty.local_name().as_ref(),
+                        SAML_PROTOCOL_NS,
+                        "Status",
+                    )
+                {
+                    return reduced_response_shell_error(
+                        "reduced signed response shell Status is missing StatusCode",
+                    );
+                } else {
+                    reject_unexpected_element(&namespace, empty.local_name().as_ref())?;
+                }
+            }
+            XmlEvent::End(end) => {
+                let closes_status = status_depth.is_some_and(|open_status_depth| {
+                    depth == open_status_depth + 1
+                        && element_is(
+                            &namespace,
+                            end.local_name().as_ref(),
+                            SAML_PROTOCOL_NS,
+                            "Status",
+                        )
+                });
+                let closes_response = depth == 1
+                    && element_is(
+                        &namespace,
+                        end.local_name().as_ref(),
+                        SAML_PROTOCOL_NS,
+                        "Response",
+                    );
+
+                if capture_depth > 0 {
+                    writer.write_event(XmlEvent::End(end.into_owned()))?;
+                    capture_depth -= 1;
+                }
+
+                if closes_status {
+                    if status_code_count == 0 {
+                        return reduced_response_shell_error(
+                            "reduced signed response shell Status is missing StatusCode",
+                        );
+                    }
+                    status_depth = None;
+                }
+
+                if closes_response {
+                    response_closed = true;
+                }
+
+                if depth == 0 {
+                    return reduced_response_shell_error(
+                        "reduced signed response shell has an unmatched end element",
+                    );
+                }
+                depth -= 1;
+                namespace_stack.pop();
+            }
+            XmlEvent::Text(text) => {
+                if capture_depth > 0 {
+                    writer.write_event(XmlEvent::Text(text.into_owned()))?;
+                } else if !xml_text_is_whitespace(text.as_ref()) {
+                    return reduced_response_shell_error(
+                        "reduced signed response shell contains non-whitespace text",
+                    );
+                }
+            }
+            XmlEvent::CData(cdata) => {
+                if capture_depth > 0 {
+                    writer.write_event(XmlEvent::CData(cdata.into_owned()))?;
+                } else if !xml_text_is_whitespace(cdata.as_ref()) {
+                    return reduced_response_shell_error(
+                        "reduced signed response shell contains non-whitespace CDATA",
+                    );
+                }
+            }
+            XmlEvent::Comment(comment) => {
+                if capture_depth > 0 {
+                    writer.write_event(XmlEvent::Comment(comment.into_owned()))?;
+                } else {
+                    return reduced_response_shell_error(
+                        "reduced signed response shell contains an unexpected comment",
+                    );
+                }
+            }
+            XmlEvent::Decl(_) if !root_seen => {}
+            XmlEvent::Eof => break,
+            event => {
+                if capture_depth > 0 {
+                    writer.write_event(event.into_owned())?;
+                } else {
+                    return reduced_response_shell_error(
+                        "reduced signed response shell contains unexpected XML content",
+                    );
+                }
+            }
+        }
+    }
+
+    if !root_seen {
+        return reduced_response_shell_error(
+            "reduced signed response shell is missing Response root",
+        );
+    }
+
+    if assertion_count != 1 {
+        return reduced_response_shell_error(
+            "reduced signed response shell must contain exactly one direct SAML assertion",
+        );
+    }
+
+    Ok(String::from_utf8(writer.into_inner().into_inner())?)
+}
+
+fn require_response_root(
+    namespace: &ResolveResult<'_>,
+    local_name: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    if element_is(namespace, local_name, SAML_PROTOCOL_NS, "Response") {
+        Ok(())
+    } else {
+        reduced_response_shell_error("reduced signed response shell root is not a SAML Response")
+    }
+}
+
+fn require_status_code(
+    namespace: &ResolveResult<'_>,
+    local_name: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    if element_is(namespace, local_name, SAML_PROTOCOL_NS, "StatusCode") {
+        Ok(())
+    } else {
+        reduced_response_shell_error(
+            "reduced signed response shell Status contains an unexpected element",
+        )
+    }
+}
+
+fn reject_content_after_response(response_closed: bool) -> Result<(), Box<dyn std::error::Error>> {
+    if response_closed {
+        reduced_response_shell_error(
+            "reduced signed response shell contains content after Response",
+        )
+    } else {
+        Ok(())
+    }
+}
+
+fn reject_multiple_assertions(assertion_count: usize) -> Result<(), Box<dyn std::error::Error>> {
+    if assertion_count > 1 {
+        reduced_response_shell_error(
+            "reduced signed response shell contains multiple direct SAML assertions",
+        )
+    } else {
+        Ok(())
+    }
+}
+
+fn reject_nested_assertion(
+    namespace: &ResolveResult<'_>,
+    local_name: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    if element_is(namespace, local_name, SAML_ASSERTION_NS, "Assertion") {
+        reduced_response_shell_error(
+            "reduced signed response shell contains a nested SAML assertion",
+        )
+    } else {
+        Ok(())
+    }
+}
+
+fn reject_unexpected_element(
+    namespace: &ResolveResult<'_>,
+    local_name: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    if local_name_is(local_name, "Assertion")
+        && !element_is(namespace, local_name, SAML_ASSERTION_NS, "Assertion")
+    {
+        reduced_response_shell_error(
+            "reduced signed response shell contains an Assertion outside the SAML assertion namespace",
+        )
+    } else if local_name_is(local_name, "Status")
+        && !element_is(namespace, local_name, SAML_PROTOCOL_NS, "Status")
+    {
+        reduced_response_shell_error(
+            "reduced signed response shell contains a Status outside the SAML protocol namespace",
+        )
+    } else {
+        reduced_response_shell_error(
+            "reduced signed response shell contains an unexpected direct child element",
+        )
+    }
+}
+
+fn validate_only_namespace_declarations(
+    start: &BytesStart<'_>,
+    element_name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for attribute in start.attributes() {
+        let attribute = attribute?;
+        if !attribute_is_namespace_declaration(attribute.key.as_ref()) {
+            return reduced_response_shell_error(format!(
+                "reduced signed response shell {element_name} contains a non-namespace attribute"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_status_code(start: &BytesStart<'_>) -> Result<(), Box<dyn std::error::Error>> {
+    let mut value = None;
+
+    for attribute in start.attributes() {
+        let attribute = attribute?;
+        let key = attribute.key.as_ref();
+        if attribute_is_namespace_declaration(key) {
+            continue;
+        }
+
+        if key == b"Value" {
+            value = Some(String::from_utf8_lossy(attribute.value.as_ref()).into_owned());
+        } else {
+            return reduced_response_shell_error(
+                "reduced signed response shell StatusCode contains an unexpected attribute",
+            );
+        }
+    }
+
+    match value.as_deref() {
+        Some(SAML_STATUS_SUCCESS) => Ok(()),
+        Some(code) => reduced_response_shell_error(format!(
+            "reduced signed response shell StatusCode is not successful: {code}"
+        )),
+        None => reduced_response_shell_error(
+            "reduced signed response shell StatusCode is missing Value",
+        ),
+    }
+}
+
+fn standalone_assertion_start(
+    start: BytesStart<'_>,
+    namespace_stack: &[Vec<(String, String)>],
+) -> Result<BytesStart<'static>, Box<dyn std::error::Error>> {
+    let declared_on_assertion = namespace_stack.last().cloned().unwrap_or_default();
+    let mut standalone = start.into_owned();
+
+    for (prefix, href) in in_scope_namespaces(namespace_stack) {
+        if namespace_is_declared(&declared_on_assertion, &prefix) {
+            continue;
+        }
+
+        let attribute_name = namespace_attribute_name(&prefix);
+        standalone.push_attribute((attribute_name.as_str(), href.as_str()));
+    }
+
+    Ok(standalone)
+}
+
+fn namespace_declarations(
+    start: &BytesStart<'_>,
+) -> Result<Vec<(String, String)>, Box<dyn std::error::Error>> {
+    let mut declarations = Vec::new();
+
+    for attribute in start.attributes() {
+        let attribute = attribute?;
+        let key = String::from_utf8_lossy(attribute.key.as_ref());
+        let prefix = if key == "xmlns" {
+            Some(String::new())
+        } else {
+            key.strip_prefix("xmlns:").map(ToString::to_string)
+        };
+
+        if let Some(prefix) = prefix {
+            declarations.push((
+                prefix,
+                String::from_utf8_lossy(attribute.value.as_ref()).into_owned(),
+            ));
+        }
+    }
+
+    Ok(declarations)
+}
+
+fn in_scope_namespaces(namespace_stack: &[Vec<(String, String)>]) -> Vec<(String, String)> {
+    let mut namespaces = Vec::new();
+
+    for frame in namespace_stack {
+        for (prefix, href) in frame {
+            if let Some(existing) = namespaces
+                .iter_mut()
+                .find(|(existing_prefix, _)| existing_prefix == prefix)
+            {
+                existing.1 = href.clone();
+            } else {
+                namespaces.push((prefix.clone(), href.clone()));
+            }
+        }
+    }
+
+    namespaces
+}
+
+fn namespace_is_declared(declarations: &[(String, String)], prefix: &str) -> bool {
+    declarations
+        .iter()
+        .any(|(declared_prefix, _)| declared_prefix == prefix)
+}
+
+fn namespace_attribute_name(prefix: &str) -> String {
+    if prefix.is_empty() {
+        "xmlns".to_string()
+    } else {
+        format!("xmlns:{prefix}")
+    }
+}
+
+fn element_is(
+    namespace: &ResolveResult<'_>,
+    local_name: &[u8],
+    expected_namespace: &str,
+    expected_local_name: &str,
+) -> bool {
+    matches!(namespace, ResolveResult::Bound(bound) if bound.as_ref() == expected_namespace.as_bytes())
+        && local_name_is(local_name, expected_local_name)
+}
+
+fn local_name_is(local_name: &[u8], expected: &str) -> bool {
+    local_name == expected.as_bytes()
+}
+
+fn attribute_is_namespace_declaration(attribute_name: &[u8]) -> bool {
+    attribute_name == b"xmlns" || attribute_name.starts_with(b"xmlns:")
+}
+
+fn xml_text_is_whitespace(text: &[u8]) -> bool {
+    text.iter()
+        .all(|byte| matches!(byte, b' ' | b'\n' | b'\r' | b'\t'))
+}
+
+fn reduced_response_shell_error<T>(
+    message: impl Into<String>,
+) -> Result<T, Box<dyn std::error::Error>> {
+    Err(Box::new(DeError::Custom(message.into())))
 }
 
 fn parse_certificates(key_descriptor: &KeyDescriptor) -> Result<Vec<CertificateDer>, Error> {
@@ -813,5 +1342,181 @@ impl AuthnRequest {
         _private_key: &<Crypto as CryptoProvider>::PrivateKey,
     ) -> Result<Option<Url>, Box<dyn std::error::Error>> {
         Err(Box::new(CryptoError::CryptoDisabled))
+    }
+}
+
+#[cfg(test)]
+mod reduced_response_shell_tests {
+    use super::*;
+
+    const DIRECT_ASSERTION_SHELL: &str = r#"
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                 xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+  <saml:Assertion/>
+</saml2p:Response>
+"#;
+
+    #[test]
+    fn reduced_response_shell_accepts_single_direct_assertion_and_reconstructs_inherited_namespaces(
+    ) {
+        let xml = r#"
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                 xmlns="urn:oasis:names:tc:SAML:2.0:assertion"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <Assertion>
+    <Issuer>http://idp.example.com/metadata.php</Issuer>
+  </Assertion>
+</saml2p:Response>
+"#;
+
+        let assertion_xml = verified_assertion_from_response_shell(xml)
+            .expect("single direct SAML assertion should be extracted");
+
+        assert!(assertion_xml.starts_with("<Assertion"));
+        assert!(assertion_xml.contains("xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\""));
+        assert!(assertion_xml.contains("xmlns:xs=\"http://www.w3.org/2001/XMLSchema\""));
+        assert!(assertion_xml.contains("<Issuer>http://idp.example.com/metadata.php</Issuer>"));
+    }
+
+    #[test]
+    fn reduced_response_shell_accepts_success_status_and_single_direct_assertion() {
+        let xml = r#"
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                 xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+  <saml2p:Status>
+    <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </saml2p:Status>
+  <saml:Assertion/>
+</saml2p:Response>
+"#;
+
+        let assertion_xml = verified_assertion_from_response_shell(xml)
+            .expect("success Status should be allowed in the reduced shell");
+
+        assert!(assertion_xml.starts_with("<saml:Assertion"));
+    }
+
+    #[test]
+    fn reduced_response_shell_rejects_non_success_status() {
+        let xml = r#"
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                 xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+  <saml2p:Status>
+    <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Requester"/>
+  </saml2p:Status>
+  <saml:Assertion/>
+</saml2p:Response>
+"#;
+
+        assert!(verified_assertion_from_response_shell(xml).is_err());
+    }
+
+    #[test]
+    fn reduced_response_shell_rejects_multiple_direct_assertions() {
+        let xml = DIRECT_ASSERTION_SHELL.replace(
+            "  <saml:Assertion/>",
+            "  <saml:Assertion/>\n  <saml:Assertion/>",
+        );
+
+        assert!(verified_assertion_from_response_shell(&xml).is_err());
+    }
+
+    #[test]
+    fn reduced_response_shell_rejects_wrong_namespace_assertion() {
+        let wrong_namespace = r#"
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                 xmlns:evil="urn:example:evil">
+  <evil:Assertion/>
+</saml2p:Response>
+"#;
+        let no_namespace = r#"
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol">
+  <Assertion/>
+</saml2p:Response>
+"#;
+
+        assert!(verified_assertion_from_response_shell(wrong_namespace).is_err());
+        assert!(verified_assertion_from_response_shell(no_namespace).is_err());
+    }
+
+    #[test]
+    fn reduced_response_shell_rejects_nested_assertion() {
+        let xml = r#"
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                 xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+  <Container>
+    <saml:Assertion/>
+  </Container>
+</saml2p:Response>
+"#;
+
+        assert!(verified_assertion_from_response_shell(xml).is_err());
+    }
+
+    #[test]
+    fn reduced_response_shell_rejects_assertion_nested_inside_direct_assertion() {
+        let xml = r#"
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                 xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+  <saml:Assertion>
+    <saml:Assertion/>
+  </saml:Assertion>
+</saml2p:Response>
+"#;
+
+        assert!(verified_assertion_from_response_shell(xml).is_err());
+    }
+
+    #[test]
+    fn reduced_response_shell_rejects_signature_object_assertion() {
+        let xml = r#"
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                 xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                 xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+  <ds:Signature>
+    <ds:Object>
+      <saml:Assertion/>
+    </ds:Object>
+  </ds:Signature>
+</saml2p:Response>
+"#;
+
+        assert!(verified_assertion_from_response_shell(xml).is_err());
+    }
+
+    #[test]
+    fn reduced_response_shell_rejects_response_attributes() {
+        let xml = DIRECT_ASSERTION_SHELL.replace(
+            "<saml2p:Response ",
+            "<saml2p:Response ID=\"unsigned-wrapper\" ",
+        );
+
+        assert!(verified_assertion_from_response_shell(&xml).is_err());
+    }
+
+    #[test]
+    fn saml_root_element_classifies_only_saml_protocol_response_and_assertion_roots() {
+        let protocol_response =
+            r#"<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"/>"#;
+        let assertion = r#"<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"/>"#;
+        let local_name_only_response = r#"<Response xmlns="urn:example:wrong"/>"#;
+        let wrong_namespace_assertion = r#"<evil:Assertion xmlns:evil="urn:example:evil"/>"#;
+
+        assert_eq!(
+            saml_root_element(protocol_response).unwrap(),
+            Some(SamlRootElement::ProtocolResponse)
+        );
+        assert_eq!(
+            saml_root_element(assertion).unwrap(),
+            Some(SamlRootElement::Assertion)
+        );
+        assert_eq!(
+            saml_root_element(local_name_only_response).unwrap(),
+            Some(SamlRootElement::Unsupported)
+        );
+        assert_eq!(
+            saml_root_element(wrong_namespace_assertion).unwrap(),
+            Some(SamlRootElement::Unsupported)
+        );
     }
 }

--- a/src/service_provider/tests.rs
+++ b/src/service_provider/tests.rs
@@ -278,6 +278,34 @@ mod encrypted_assertion_tests {
             .unwrap()
     }
 
+    fn create_multi_signed_response_sp() -> ServiceProvider {
+        let idp_metadata = r#"<?xml version="1.0"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://some.idp.test/blah/">
+  <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>MIIB+jCCAWOgAwIBAgIUdcXUPTE+mOSWxRCJh8ldmDMPzREwDQYJKoZIhvcNAQELBQAwDzENMAsGA1UEAwwEVGVzdDAeFw0yNjA0MDIxMjQzMTNaFw0yNzA0MDIxMjQzMTNaMA8xDTALBgNVBAMMBFRlc3QwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAJEBNDJKH5nXr0hZKcSNIY1l4HeYLPBEKJLXyAnoFTdgGrvi40YyIx9lHh0LbDVWCgxJp21BmKll0CkgmeKidvGlr3FUwtETro44L+SgmjiJNbftvFxhNkgA26O2GDQuBoQwgSiagVadWXwJKkodH8tx4ojBPYK1pBO8fHf3wOnxAgMBAAGjUzBRMB0GA1UdDgQWBBSLoT4AEwcK1+0IMwgo6JYfA4e8ZTAfBgNVHSMEGDAWgBSLoT4AEwcK1+0IMwgo6JYfA4e8ZTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4GBAAtV1hclbZBD17LMbBwyrTj7szmmeUVISPeFEPaAKqiTXrHwRZ+akajboB2JjT3YYMXX2/eDaSvq9f20vJQUvkEAaYu8eNNDKWgm4btJFAeJT8uGxizmTspdJ0cxFSwxqaosV3qIqJgpwLbzUXEcu6mKfyqDM6AeFZdZevkxmKlE</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://some.idp.test/blah/"/>
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://some.idp.test/blah/"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>
+"#
+        .parse()
+        .unwrap();
+
+        let mut sp = create_predigest_assertion_sp_with_metadata(
+            "https://api.dev.zoo.dev/auth/saml/00000000-00000000-00000000-00000000/login",
+            idp_metadata,
+        );
+        sp.allow_idp_initiated = true;
+        sp
+    }
+
     fn refresh_assertion_validation_windows(assertion: &mut Assertion) {
         if let Some(conditions) = assertion.conditions.as_mut() {
             conditions.not_before = Some(Utc::now() - Duration::minutes(1));
@@ -417,15 +445,15 @@ mod encrypted_assertion_tests {
     fn test_validate_and_mark_only_assertion_signed() {
         let sp = create_predigest_assertion_sp("http://sp.example.com/demo1/index.php?acs");
         let response_xml = include_str!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/test_vectors/response_signed_assertion.xml"
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/response_signed_assertion.xml"
         ));
 
         let assertion = sp
             .parse_xml_response_with_mode(
                 &response_xml,
                 Some(&["ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"]),
-                ReduceMode::ValidateAndMark
+                ReduceMode::ValidateAndMark,
             )
             .unwrap();
 
@@ -606,33 +634,121 @@ mod encrypted_assertion_tests {
             Error::AssertionSubjectConfirmationExpiredBefore { .. }
         ));
     }
-
     #[test]
     fn test_parse_xml_response_with_empty_saml_response() {
-        let mut sp = create_predigest_assertion_sp_with_metadata("https://api.dev.zoo.dev/auth/saml/00000000-00000000-00000000-00000000/login", r#"<?xml version="1.0"?>
-<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://some.idp.test/blah/">
-  <md:IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-    <md:KeyDescriptor use="signing">
-      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-        <ds:X509Data>
-          <ds:X509Certificate>MIIB+jCCAWOgAwIBAgIUdcXUPTE+mOSWxRCJh8ldmDMPzREwDQYJKoZIhvcNAQELBQAwDzENMAsGA1UEAwwEVGVzdDAeFw0yNjA0MDIxMjQzMTNaFw0yNzA0MDIxMjQzMTNaMA8xDTALBgNVBAMMBFRlc3QwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAJEBNDJKH5nXr0hZKcSNIY1l4HeYLPBEKJLXyAnoFTdgGrvi40YyIx9lHh0LbDVWCgxJp21BmKll0CkgmeKidvGlr3FUwtETro44L+SgmjiJNbftvFxhNkgA26O2GDQuBoQwgSiagVadWXwJKkodH8tx4ojBPYK1pBO8fHf3wOnxAgMBAAGjUzBRMB0GA1UdDgQWBBSLoT4AEwcK1+0IMwgo6JYfA4e8ZTAfBgNVHSMEGDAWgBSLoT4AEwcK1+0IMwgo6JYfA4e8ZTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4GBAAtV1hclbZBD17LMbBwyrTj7szmmeUVISPeFEPaAKqiTXrHwRZ+akajboB2JjT3YYMXX2/eDaSvq9f20vJQUvkEAaYu8eNNDKWgm4btJFAeJT8uGxizmTspdJ0cxFSwxqaosV3qIqJgpwLbzUXEcu6mKfyqDM6AeFZdZevkxmKlE</ds:X509Certificate>
-        </ds:X509Data>
-      </ds:KeyInfo>
-    </md:KeyDescriptor>
-    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://some.idp.test/blah/"/>
-    <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
-    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://some.idp.test/blah/"/>
-  </md:IDPSSODescriptor>
-</md:EntityDescriptor>
-"#.parse().unwrap());
-        sp.allow_idp_initiated = true;
+        let sp = create_multi_signed_response_sp();
         let response_xml = include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/test_vectors/multi_saml_response_signed_2.xml"
         ));
 
-        let assertion = sp
-            .parse_xml_response_with_mode(response_xml, None, ReduceMode::PreDigest)
+        sp.parse_xml_response_with_mode(response_xml, None, ReduceMode::PreDigest)
             .expect("signed assertion should parse in pre-digest mode");
+    }
+
+    #[test]
+    fn test_allowed_signature_algorithms_accepts_listed_algorithm() {
+        use crate::crypto::AllowedSignatureAlgorithm;
+
+        let mut sp = create_multi_signed_response_sp();
+        sp.allowed_signature_algorithms = Some(vec![AllowedSignatureAlgorithm::RsaSha256]);
+
+        let response_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/multi_saml_response_signed_2.xml"
+        ));
+
+        sp.parse_xml_response_with_mode(response_xml, None, ReduceMode::PreDigest)
+            .expect("RSA-SHA256 should verify when RSA-SHA256 is allowed");
+    }
+
+    #[test]
+    fn test_allowed_signature_algorithms_rejects_weak_algorithms() {
+        use crate::crypto::AllowedSignatureAlgorithm;
+
+        let idp_metadata: EntityDescriptor = include_str!("../../test_vectors/idp_metadata.xml")
+            .parse()
+            .unwrap();
+
+        // Create a ServiceProvider that only allows strong algorithms (SHA256 and above)
+        let sp = ServiceProviderBuilder::default()
+            .idp_metadata(idp_metadata)
+            .acs_url(Some("http://sp.example.com/acs".to_string()))
+            .allowed_signature_algorithms(Some(vec![
+                AllowedSignatureAlgorithm::RsaSha256,
+                AllowedSignatureAlgorithm::EcdsaSha256,
+                AllowedSignatureAlgorithm::RsaSha384,
+                AllowedSignatureAlgorithm::RsaSha512,
+            ]))
+            .build()
+            .unwrap();
+
+        // Verify the configuration is set
+        assert!(sp.allowed_signature_algorithms.is_some());
+        assert_eq!(sp.allowed_signature_algorithms.as_ref().unwrap().len(), 4);
+
+        // Test that a response signed with weak RSA-SHA1 is REJECTED
+        // This test vector is signed with RSA-SHA1, which is NOT in our allowed list
+        let response_xml = include_str!("../../test_vectors/response_signed_by_idp_2.xml");
+        let result =
+            sp.parse_xml_response(response_xml, Some(&["id-sRfZ4Fe8w3bPPOtxPcLEYW6aWpZm"]));
+
+        // This should FAIL because RSA-SHA1 is not in the allowed list
+        assert!(
+            result.is_err(),
+            "RSA-SHA1 should be rejected when not in allowed list"
+        );
+        assert!(matches!(result, Err(Error::FailedToValidateSignature)));
+    }
+
+    #[test]
+    fn test_allowed_signature_algorithms_rejects_weak_digest_methods() {
+        use crate::crypto::AllowedSignatureAlgorithm;
+
+        let idp_metadata_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/idp_ecdsa_metadata.xml"
+        ));
+        let response_instant = "2014-07-17T01:01:48Z".parse::<DateTime<Utc>>().unwrap();
+        let sp = ServiceProvider {
+            metadata_url: Some("http://test_accept_signed_with_correct_key.test".into()),
+            acs_url: Some("http://sp.example.com/demo1/index.php?acs".into()),
+            idp_metadata: idp_metadata_xml.parse().unwrap(),
+            max_issue_delay: Utc::now() - response_instant + Duration::seconds(60),
+            allowed_signature_algorithms: Some(vec![AllowedSignatureAlgorithm::EcdsaSha256]),
+            ..Default::default()
+        };
+
+        let response_xml = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/test_vectors/response_signed_by_idp_ecdsa.xml"
+        ));
+        let result = sp.parse_xml_response(
+            response_xml,
+            Some(&["ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"]),
+        );
+
+        assert!(matches!(result, Err(Error::FailedToValidateSignature)));
+    }
+
+    #[test]
+    fn test_default_has_no_algorithm_restrictions() {
+        let idp_metadata: EntityDescriptor = include_str!("../../test_vectors/idp_metadata.xml")
+            .parse()
+            .unwrap();
+
+        // ServiceProvider without explicit algorithm restrictions
+        let sp = ServiceProviderBuilder::default()
+            .idp_metadata(idp_metadata)
+            .acs_url(Some("http://sp.example.com/acs".to_string()))
+            .build()
+            .unwrap();
+
+        // Verify no restrictions are set by default
+        assert!(sp.allowed_signature_algorithms.is_none());
+
+        // Note: All other existing tests in the suite pass without restrictions,
+        // demonstrating that the default behavior (no restrictions) works correctly.
+        // This test simply verifies that the field defaults to None.
     }
 }


### PR DESCRIPTION
Port dev shell to devenv and fix xmlsec transforms

- Add devenv shell wiring around the shared Nix build environment
- Use generic xmlsec transform getters exposed by dynamic backend headers
- Treat assertion-only ValidateAndMark output as a verified assertion shell

Remove direnv

Harden SAML response fallback and align Nix docs

Require namespace-aware SAML roots and strict verified Response shell extraction. Preserve inherited namespaces during xmlsec child-root reduction. Replace standalone devenv locks/docs with the flake.lock environment story.

Ignore .tmp

Fix devenv